### PR TITLE
Fix clippy issues

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["glTF"]

--- a/examples/display/main.rs
+++ b/examples/display/main.rs
@@ -33,7 +33,7 @@ fn run(path: &str) -> Result<(), Box<StdError>> {
 
 fn main() {
     if let Some(path) = std::env::args().nth(1) {
-        let _ = run(&path).expect("runtime error");
+        run(&path).expect("runtime error");
     } else {
         println!("usage: gltf-display <FILE>");
     }

--- a/examples/tree/main.rs
+++ b/examples/tree/main.rs
@@ -53,7 +53,7 @@ fn run(path: &str) -> Result<(), Box<StdError>> {
 
 fn main() {
     if let Some(path) = std::env::args().nth(1) {
-        let _ = run(&path).expect("runtime error");
+        run(&path).expect("runtime error");
     } else {
         println!("usage: gltf-tree <FILE>");
     }

--- a/gltf-importer/src/lib.rs
+++ b/gltf-importer/src/lib.rs
@@ -9,7 +9,7 @@
 
 //! The reference loader implementation for the `gltf` crate.
 //!
-//! # Examples 
+//! # Examples
 //!
 //! ### Importing some `glTF` 2.0
 //!
@@ -50,7 +50,7 @@ pub enum Error {
 
     /// Base 64 decoding error.
     Base64Decoding(base64::DecodeError),
-    
+
     /// A glTF extension required by the asset has not been enabled by the user.
     ExtensionDisabled(String),
 
@@ -105,17 +105,17 @@ impl Buffers {
     }
 }
 
-fn import_impl(path: &Path, config: Config) -> Result<(Gltf, Buffers), Error> {
+fn import_impl(path: &Path, config: &Config) -> Result<(Gltf, Buffers), Error> {
     let data = read_to_end(path)?;
     if data.starts_with(b"glTF") {
-        import_binary(&data, &config, path)
+        import_binary(&data, config, path)
     } else {
-        import_standard(&data, &config, path)
+        import_standard(&data, config, path)
     }
-}   
+}
 
 /// Imports glTF 2.0 with custom configuration.
-pub fn import_with_config<P>(path: P, config: Config) -> Result<(Gltf, Buffers), Error>
+pub fn import_with_config<P>(path: P, config: &Config) -> Result<(Gltf, Buffers), Error>
     where P: AsRef<Path>
 {
     import_impl(path.as_ref(), config)
@@ -125,7 +125,7 @@ pub fn import_with_config<P>(path: P, config: Config) -> Result<(Gltf, Buffers),
 pub fn import<P>(path: P) -> Result<(Gltf, Buffers), Error>
     where P: AsRef<Path>
 {
-    import_impl(path.as_ref(), Default::default())
+    import_impl(path.as_ref(), &Default::default())
 }
 
 fn read_to_end_impl(path: &Path) -> Result<Vec<u8>, Error> {
@@ -142,11 +142,11 @@ fn read_to_end<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Error> {
 }
 
 fn parse_data_uri(uri: &str) -> Result<Vec<u8>, Error> {
-    let encoded = uri.split(",").nth(1).unwrap();
+    let encoded = uri.split(',').nth(1).unwrap();
     let decoded = base64::decode(&encoded)?;
     Ok(decoded)
 }
-    
+
 fn load_external_buffers(
     base_path: &Path,
     gltf: &Gltf,
@@ -160,7 +160,7 @@ fn load_external_buffers(
         } else if uri.starts_with("data:") {
             Ok(parse_data_uri(uri)?)
         } else {
-            let path = base_path.parent().unwrap_or(Path::new("./")).join(uri);
+            let path = base_path.parent().unwrap_or_else(|| Path::new("./")).join(uri);
             read_to_end(&path)
         }?;
         if data.len() < buffer.length() {
@@ -235,7 +235,7 @@ fn import_standard<'a>(
     base_path: &Path,
 ) -> Result<(Gltf, Buffers), Error> {
     let unvalidated = Gltf::from_slice(data)?;
-    let gltf = validate_standard(unvalidated, &config)?;
+    let gltf = validate_standard(unvalidated, config)?;
     let bin = None;
     let mut buffers = Buffers(vec![]);
     for buffer in load_external_buffers(base_path, &gltf, bin)? {
@@ -249,10 +249,10 @@ fn import_binary<'a>(
     config: &Config,
     base_path: &Path,
 ) -> Result<(Gltf, Buffers), Error> {
-    let gltf::Glb { header: _, json, bin } = gltf::Glb::from_slice(data)?;
+    let gltf::Glb { json, bin, .. } = gltf::Glb::from_slice(data)?;
     let unvalidated = Gltf::from_slice(json)?;
     let bin = bin.map(|x| x.to_vec());
-    let gltf = validate_binary(unvalidated, &config, bin.is_some())?;
+    let gltf = validate_binary(unvalidated, config, bin.is_some())?;
     let mut buffers = Buffers(vec![]);
     for buffer in load_external_buffers(base_path, &gltf, bin)? {
         buffers.0.push(buffer);

--- a/gltf-importer/tests/import_examples.rs
+++ b/gltf-importer/tests/import_examples.rs
@@ -22,6 +22,7 @@ fn import_from_path(path: &path::Path) -> Result<(), ImportError> {
     }
 }
 
+#[allow(type_complexity)]
 fn run() -> Result<Vec<(path::PathBuf, Result<(), ImportError>)>, Box<StdError>> {
     let sample_dir_path = path::Path::new("../glTF-Sample-Models/2.0");
     let mut results = vec![];

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -191,27 +191,27 @@ pub struct Accessor {
     /// The parent buffer view this accessor reads from.
     #[serde(rename = "bufferView")]
     pub buffer_view: Index<buffer::View>,
-    
+
     /// The offset relative to the start of the parent `BufferView` in bytes.
     #[serde(default, rename = "byteOffset")]
     pub byte_offset: u32,
-    
+
     /// The number of components within the buffer view - not to be confused
     /// with the number of bytes in the buffer view.
     pub count: u32,
-    
+
     /// The data type of components in the attribute.
     #[serde(rename = "componentType")]
     pub component_type: Checked<GenericComponentType>,
-    
+
     /// Extension specific data.
     #[serde(default)]
     pub extensions: extensions::accessor::Accessor,
-    
+
     /// Optional application specific data.
     #[serde(default)]
     pub extras: Extras,
-    
+
     /// Specifies if the attribute is a scalar, vector, or matrix.
     #[serde(rename = "type")]
     pub type_: Checked<Type>,
@@ -231,7 +231,7 @@ pub struct Accessor {
     /// Specifies whether integer data values should be normalized.
     #[serde(default)]
     pub normalized: bool,
-    
+
     /// Sparse storage of attributes that deviate from their initialization
     /// value.
     #[serde(default)]
@@ -360,8 +360,7 @@ impl Type {
             Scalar => 1,
             Vec2 => 2,
             Vec3 => 3,
-            Vec4 => 4,
-            Mat2 => 4,
+            Vec4 | Mat2 => 4,
             Mat3 => 9,
             Mat4 => 16,
         }

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -13,10 +13,10 @@ use validation::{Checked, Error, Validate};
 use {extensions, Extras, Index, Root, Path};
 
 /// Corresponds to `GL_ARRAY_BUFFER`.
-pub const ARRAY_BUFFER: u32 = 34962;
+pub const ARRAY_BUFFER: u32 = 34_962;
 
 /// Corresponds to `GL_ELEMENT_ARRAY_BUFFER`.
-pub const ELEMENT_ARRAY_BUFFER: u32 = 34963;
+pub const ELEMENT_ARRAY_BUFFER: u32 = 34_963;
 
 /// The minimum byte stride.
 pub const MIN_BYTE_STRIDE: u32 = 4;
@@ -30,7 +30,7 @@ pub const VALID_TARGETS: &'static [u32] = &[
     ELEMENT_ARRAY_BUFFER,
 ];
 
-/// Specifies the target a GPU buffer should be bound to. 
+/// Specifies the target a GPU buffer should be bound to.
 #[derive(Clone, Copy, Debug)]
 pub enum Target {
     /// Corresponds to `GL_ARRAY_BUFFER`.

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -311,25 +311,25 @@ impl Semantic {
 impl ToString for Semantic {
     fn to_string(&self) -> String {
         use self::Semantic::*;
-        match self {
-            &Positions => format!("POSITION"),
-            &Normals => format!("NORMAL"),
-            &Tangents => format!("TANGENT"),
-            &Colors(set) => format!("COLOR_{}", set),
-            &TexCoords(set) => format!("TEXCOORD_{}", set),
-            &Joints(set) => format!("JOINTS_{}", set),
-            &Weights(set) => format!("WEIGHTS_{}", set),
+        match *self {
+            Positions => "POSITION".into(),
+            Normals => "NORMAL".into(),
+            Tangents => "TANGENT".into(),
+            Colors(set) => format!("COLOR_{}", set),
+            TexCoords(set) => format!("TEXCOORD_{}", set),
+            Joints(set) => format!("JOINTS_{}", set),
+            Weights(set) => format!("WEIGHTS_{}", set),
             #[cfg(feature = "extras")]
-            &Extras(ref name) => format!("_{}", name),
+            Extras(ref name) => format!("_{}", name),
         }
     }
 }
 
 impl ToString for Checked<Semantic> {
     fn to_string(&self) -> String {
-        match self {
-            &Checked::Valid(ref semantic) => semantic.to_string(),
-            &Checked::Invalid => format!("<invalid semantic name>"),
+        match *self {
+            Checked::Valid(ref semantic) => semantic.to_string(),
+            Checked::Invalid => "<invalid semantic name>".into(),
         }
     }
 }

--- a/gltf-json/src/path.rs
+++ b/gltf-json/src/path.rs
@@ -10,7 +10,7 @@
 use std::fmt;
 
 /// An immutable JSON source path.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub struct Path(pub String);
 
 impl Path {

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -31,13 +31,13 @@ pub const NEAREST_MIPMAP_LINEAR: u32 = 9986;
 pub const LINEAR_MIPMAP_LINEAR: u32 = 9987;
 
 /// Corresponds to `GL_CLAMP_TO_EDGE`.
-pub const CLAMP_TO_EDGE: u32 = 33071;
+pub const CLAMP_TO_EDGE: u32 = 33_071;
 
 /// Corresponds to `GL_MIRRORED_REPEAT`.
-pub const MIRRORED_REPEAT: u32 = 33648;
+pub const MIRRORED_REPEAT: u32 = 33_648;
 
 /// Corresponds to `GL_REPEAT`.
-pub const REPEAT: u32 = 10497;
+pub const REPEAT: u32 = 10_497;
 
 /// All valid magnification filters.
 pub const VALID_MAG_FILTERS: &'static [u32] = &[

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -65,9 +65,9 @@ pub enum Checked<T> {
 impl<T> Checked<T> {
     /// Converts from `Checked<T>` to `Checked<&T>`.
     pub fn as_ref(&self) -> Checked<&T> {
-        match self {
-            &Checked::Valid(ref item) => Checked::Valid(item),
-            &Checked::Invalid => Checked::Invalid,
+        match *self {
+            Checked::Valid(ref item) => Checked::Valid(item),
+            Checked::Invalid => Checked::Invalid,
         }
     }
 
@@ -86,9 +86,9 @@ impl<T> Checked<T> {
 
 impl<T: Clone> Clone for Checked<T> {
     fn clone(&self) -> Self {
-        match self {
-            &Checked::Valid(ref item) => Checked::Valid(item.clone()),
-            &Checked::Invalid => Checked::Invalid,
+        match *self {
+            Checked::Valid(ref item) => Checked::Valid(item.clone()),
+            Checked::Invalid => Checked::Invalid,
         }
     }
 }
@@ -105,9 +105,9 @@ impl<T> Validate for Checked<T> {
     fn validate_minimally<P, R>(&self, _root: &Root, path: P, report: &mut R)
         where P: Fn() -> Path, R: FnMut(&Fn() -> Path, Error)
     {
-        match self {
-            &Checked::Valid(_) => {},
-            &Checked::Invalid => report(&path, Error::Invalid),
+        match *self {
+            Checked::Valid(_) => {},
+            Checked::Invalid => report(&path, Error::Invalid),
         }
     }
 }
@@ -170,10 +170,10 @@ impl<T: Validate> Validate for Vec<T> {
 
 impl std::error::Error for Error {
     fn description(&self) -> &str {
-        match self {
-            &Error::IndexOutOfBounds => "Index out of bounds",
-            &Error::Invalid => "Invalid value",
-            &Error::Missing => "Missing data",
+        match *self {
+            Error::IndexOutOfBounds => "Index out of bounds",
+            Error::Invalid => "Invalid value",
+            Error::Missing => "Missing data",
         }
     }
 }

--- a/gltf-json/tests/test_validation.rs
+++ b/gltf-json/tests/test_validation.rs
@@ -17,7 +17,7 @@ fn test_accessor_bounds_validate_minimally() {
     let mut errs = vec![];
     json.validate_minimally(
         &json,
-        || gltf_json::Path::new(),
+        gltf_json::Path::new,
         &mut |path, err| errs.push((path(), err)),
     );
     assert_eq!(errs,

--- a/gltf-utils/src/lib.rs
+++ b/gltf-utils/src/lib.rs
@@ -7,6 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(unknown_lints)]
+#![allow(cast_lossless)]
+
 extern crate gltf;
 
 use std::{fmt, marker, mem};
@@ -60,11 +63,11 @@ pub trait PrimitiveIterators<'a> {
     /// Visits the vertex normals of a primitive.
     fn normals<S>(&'a self, source: &'a S) -> Option<Normals<'a>>
         where S: Source;
-    
+
     /// Visits the vertex tangents of a primitive.
     fn tangents<S>(&'a self, source: &'a S) -> Option<Tangents<'a>>
         where S: Source;
-    
+
     /// Visits the vertex texture co-ordinates of a primitive.
     fn tex_coords_f32<S>(
         &'a self,
@@ -72,7 +75,7 @@ pub trait PrimitiveIterators<'a> {
         source: &'a S,
     ) -> Option<TexCoordsF32<'a>>
         where S: Source;
-    
+
     /// Visits the vertex colors of a primitive.
     fn colors_rgba_f32<S>(
         &'a self,
@@ -146,7 +149,7 @@ impl<'a> PrimitiveIterators<'a> for gltf::Primitive<'a> {
     {
         self.indices().map(|accessor| IndicesU32(Indices::new(accessor, source)))
     }
-    
+
     fn joints_u16<S>(&'a self, set: u32, source: &'a S) -> Option<JointsU16<'a>>
         where S: Source
     {
@@ -176,13 +179,13 @@ pub struct AccessorIter<'a, T> {
 
     /// Byte offset into the buffer view where the items begin.
     offset: usize,
-    
+
     /// The data we're iterating over.
     data: &'a [u8],
 
     /// The accessor we're iterating over.
     accessor: gltf::Accessor<'a>,
-    
+
     /// Consumes the data type we're returning at each iteration.
     _marker: marker::PhantomData<T>,
 }
@@ -261,7 +264,7 @@ enum Joints<'a> {
     /// Refer to the documentation on morph targets and skins for more
     /// information.
     U8(AccessorIter<'a, [u8; 4]>),
-    
+
     /// Joints of type `[u16; 4]`.
     /// Refer to the documentation on morph targets and skins for more
     /// information.
@@ -552,7 +555,7 @@ impl<'a> Iterator for Normals<'a> {
         self.0.size_hint()
     }
 }
- 
+
 impl<'a> ExactSizeIterator for Tangents<'a> {}
 impl<'a> Iterator for Tangents<'a> {
     type Item = [f32; 4];

--- a/src/gltf.rs
+++ b/src/gltf.rs
@@ -186,7 +186,7 @@ impl Unvalidated {
             let json = self.as_json();
             json.validate_minimally(
                 json,
-                || json::Path::new(),
+                json::Path::new,
                 &mut |path, err| errs.push((path(), err)),
             );
         }
@@ -205,12 +205,12 @@ impl Unvalidated {
             let json = self.as_json();
             json.validate_minimally(
                 json,
-                || json::Path::new(),
+                json::Path::new,
                 &mut |path, err| errs.push((path(), err)),
             );
             json.validate_completely(
                 json,
-                || json::Path::new(),
+                json::Path::new,
                 &mut |path, err| errs.push((path(), err)),
             );
         }
@@ -250,6 +250,7 @@ impl Gltf {
     }
 
     /// Constructs the `Gltf` wrapper from a string slice.
+    #[allow(should_implement_trait)]
     pub fn from_str(slice: &str) -> Result<Unvalidated, Error> {
         let json: json::Root = json::from_str(slice)?;
         Ok(Unvalidated(Gltf::from_json(json)))
@@ -340,7 +341,7 @@ impl Gltf {
             gltf: self,
         }
     }
-    
+
     /// Returns an `Iterator` that visits the nodes of the glTF asset.
     pub fn nodes(&self) -> Nodes {
         Nodes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 #![deny(missing_docs)]
+#![allow(unknown_lints)]
 
 //! glTF 2.0 loader
 //!

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -305,7 +305,7 @@ impl<'a> Iterator for Attributes<'a> {
         use self::Semantic::*;
         self.iter
             .next()
-            .map(|(ref key, ref index)| {
+            .map(|(key, index)| {
                 let semantic = key.as_ref().unwrap();
                 let accessor = self.gltf.accessors().nth(index.value()).unwrap();
                 match *semantic {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -20,9 +20,9 @@ type Quaternion = cgmath::Quaternion<f32>;
 
 /// 4x4 identity matrix.
 const IDENTITY: [f32; 16] = {
-    [1.0, 0.0, 0.0, 0.0, 
-     0.0, 1.0, 0.0, 0.0, 
-     0.0, 0.0, 1.0, 0.0, 
+    [1.0, 0.0, 0.0, 0.0,
+     0.0, 1.0, 0.0, 0.0,
+     0.0, 0.0, 1.0, 0.0,
      0.0, 0.0, 0.0, 1.0]
 };
 
@@ -231,7 +231,7 @@ impl<'a> Node<'a> {
 
     /// Returns the node's transform.
     pub fn transform(&self) -> Transform {
-        if let Some(matrix) = self.json.matrix.clone() {
+        if let Some(matrix) = self.json.matrix {
             unsafe {
                 Transform::Matrix {
                     matrix: mem::transmute(matrix),


### PR DESCRIPTION
Tip: append [`?w=1`](https://github.com/gltf-rs/gltf/pull/117/files?w=1) to ignore whitespace changes.

I wasn't sure about the `cast_lossless` - theses are the concrete cases: https://gist.github.com/bwasty/21ae877413e4770e4eb5d1b05ebd6284#file-gltf-clippy-txt-L408-L474