### PR TITLE
Glb::from_reader revamp

### DIFF
--- a/examples/display/main.rs
+++ b/examples/display/main.rs
@@ -14,7 +14,7 @@ fn run(path: &str) -> Result<(), Box<StdError>> {
     let _ = reader.read_to_end(&mut data)?;
     let json: json::Root = if gltf::is_binary(&data) {
         let glb = gltf::Glb::from_slice(&data)?;
-        json::from_slice(glb.json)
+        json::from_slice(&glb.json)
     } else {
         json::from_slice(&data)
     }?;

--- a/examples/tree/main.rs
+++ b/examples/tree/main.rs
@@ -27,7 +27,7 @@ fn run(path: &str) -> Result<(), Box<StdError>> {
     let _ = reader.read_to_end(&mut data)?;
     let gltf = if gltf::is_binary(&data) {
         let glb = Glb::from_slice(&data)?;
-        Gltf::from_slice(glb.json)
+        Gltf::from_slice(&glb.json)
     } else {
         Gltf::from_slice(&data)
     }?.validate_completely()?;

--- a/gltf-importer/src/lib.rs
+++ b/gltf-importer/src/lib.rs
@@ -255,8 +255,8 @@ fn import_binary<'a>(
     base_path: &Path,
 ) -> Result<(Gltf, Buffers), Error> {
     let gltf::Glb { json, bin, .. } = gltf::Glb::from_slice(data)?;
-    let unvalidated = Gltf::from_slice(json)?;
-    let bin = bin.map(|x| x.to_vec());
+    let unvalidated = Gltf::from_slice(&json)?;
+    let bin = bin.map(|x| x.into_owned());
     let gltf = validate_binary(unvalidated, config, bin.is_some())?;
     let mut buffers = Buffers(vec![]);
     for buffer in load_external_buffers(base_path, &gltf, bin)? {

--- a/src/gltf.rs
+++ b/src/gltf.rs
@@ -230,7 +230,7 @@ impl Gltf {
 
     /// Constructs the `Gltf` wrapper from binary glTF.
     pub fn from_glb(glb: &Glb) -> Result<Unvalidated, Error> {
-        Gltf::from_slice(glb.json)
+        Gltf::from_slice(&glb.json)
     }
 
     /// Constructs the `Gltf` wrapper from a reader.


### PR DESCRIPTION
This PR changes refs to Cows to make it possible for Glb to own the data.  The implementation might not be as fast and allocation-low as the old one but this one is shorter and nicer to use.

It also fixes _potential_ oversight of mine in old code where safe code implementing `io::Read::read_exact` could be exposed to uninitialized data which _potentially_ could lead to bad things like leaks of sensitive information, _in theory_.