### PR TITLE
Relax lifetimes in gltf-utils

### DIFF
--- a/gltf-utils/src/lib.rs
+++ b/gltf-utils/src/lib.rs
@@ -93,51 +93,51 @@ pub trait PrimitiveIterators<'a> {
 }
 
 impl<'a> PrimitiveIterators<'a> for gltf::Primitive<'a> {
-    fn positions<'s, S: Source>(&'a self, source: &'s S) -> Option<Positions<'s>> {
+    fn positions<'s, S: Source>(&self, source: &'s S) -> Option<Positions<'s>> {
         self.get(&gltf::Semantic::Positions)
             .map(|accessor| Positions(AccessorIter::new(accessor, source)))
     }
 
-    fn normals<'s, S: Source>(&'a self, source: &'s S) -> Option<Normals<'s>> {
+    fn normals<'s, S: Source>(&self, source: &'s S) -> Option<Normals<'s>> {
         self.get(&gltf::Semantic::Normals)
             .map(|accessor| Normals(AccessorIter::new(accessor, source)))
     }
 
-    fn tangents<'s, S: Source>(&'a self, source: &'s S) -> Option<Tangents<'s>> {
+    fn tangents<'s, S: Source>(&self, source: &'s S) -> Option<Tangents<'s>> {
         self.get(&gltf::Semantic::Tangents)
             .map(|accessor| Tangents(AccessorIter::new(accessor, source)))
     }
 
-    fn tex_coords_f32<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<TexCoordsF32<'s>> {
+    fn tex_coords_f32<'s, S: Source>(&self, set: u32, source: &'s S) -> Option<TexCoordsF32<'s>> {
         self.get(&gltf::Semantic::TexCoords(set))
             .map(|accessor| TexCoordsF32(TexCoords::new(accessor, source)))
     }
 
     fn colors_rgba_f32<'s, S: Source>(
-        &'a self,
+        &self,
         set: u32,
         default_alpha: f32,
         source: &'s S,
     ) -> Option<ColorsRgbaF32<'s>> {
         self.get(&gltf::Semantic::Colors(set))
-            .map(|accessor|
+            .map(|accessor| {
                 ColorsRgbaF32 {
                     iter: Colors::new(accessor, source),
                     default_alpha,
                 }
-            )
+            })
     }
 
-    fn indices_u32<'s, S: Source>(&'a self, source: &'s S) -> Option<IndicesU32<'s>> {
+    fn indices_u32<'s, S: Source>(&self, source: &'s S) -> Option<IndicesU32<'s>> {
         self.indices().map(|accessor| IndicesU32(Indices::new(accessor, source)))
     }
 
-    fn joints_u16<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<JointsU16<'s>> {
+    fn joints_u16<'s, S: Source>(&self, set: u32, source: &'s S) -> Option<JointsU16<'s>> {
         self.get(&gltf::Semantic::Joints(set))
             .map(|accessor| JointsU16(Joints::new(accessor, source)))
     }
 
-    fn weights_f32<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<WeightsF32<'s>> {
+    fn weights_f32<'s, S: Source>(&self, set: u32, source: &'s S) -> Option<WeightsF32<'s>> {
         self.get(&gltf::Semantic::Weights(set))
             .map(|accessor| WeightsF32(Weights::new(accessor, source)))
     }
@@ -643,7 +643,7 @@ impl Denormalize for u16 {
     }
 }
 
-impl<T: Copy + Denormalize> Denormalize for [T; 2] {
+impl<T: Denormalize> Denormalize for [T; 2] {
     type Denormalized = [T::Denormalized; 2];
     fn denormalize(&self) -> Self::Denormalized {
         [
@@ -653,7 +653,7 @@ impl<T: Copy + Denormalize> Denormalize for [T; 2] {
     }
 }
 
-impl<T: Copy + Denormalize> Denormalize for [T; 3] {
+impl<T: Denormalize> Denormalize for [T; 3] {
     type Denormalized = [T::Denormalized; 3];
     fn denormalize(&self) -> Self::Denormalized {
         [
@@ -664,7 +664,7 @@ impl<T: Copy + Denormalize> Denormalize for [T; 3] {
     }
 }
 
-impl<T: Copy + Denormalize> Denormalize for [T; 4] {
+impl<T: Denormalize> Denormalize for [T; 4] {
     type Denormalized = [T::Denormalized; 4];
     fn denormalize(&self) -> Self::Denormalized {
         [

--- a/gltf-utils/src/lib.rs
+++ b/gltf-utils/src/lib.rs
@@ -51,109 +51,93 @@ pub trait Source: fmt::Debug {
 /// Extra methods for working with `gltf::Primitive`.
 pub trait PrimitiveIterators<'a> {
     /// Visits the vertex positions of a primitive.
-    fn positions<S>(&'a self, source: &'a S) -> Option<Positions<'a>>
-        where S: Source;
+    fn positions<'s, S: Source>(&'a self, source: &'s S) -> Option<Positions<'s>>;
 
     /// Visits the vertex normals of a primitive.
-    fn normals<S>(&'a self, source: &'a S) -> Option<Normals<'a>>
-        where S: Source;
+    fn normals<'s, S: Source>(&'a self, source: &'s S) -> Option<Normals<'s>>;
 
     /// Visits the vertex tangents of a primitive.
-    fn tangents<S>(&'a self, source: &'a S) -> Option<Tangents<'a>>
-        where S: Source;
+    fn tangents<'s, S: Source>(&'a self, source: &'s S) -> Option<Tangents<'s>>;
 
     /// Visits the vertex texture co-ordinates of a primitive.
-    fn tex_coords_f32<S>(
+    fn tex_coords_f32<'s, S: Source>(
         &'a self,
         set: u32,
-        source: &'a S,
-    ) -> Option<TexCoordsF32<'a>>
-        where S: Source;
+        source: &'s S,
+    ) -> Option<TexCoordsF32<'s>>;
 
     /// Visits the vertex colors of a primitive.
-    fn colors_rgba_f32<S>(
+    fn colors_rgba_f32<'s, S: Source>(
         &'a self,
         set: u32,
         default_alpha: f32,
-        source: &'a S,
-    ) -> Option<ColorsRgbaF32<'a>>
-        where S: Source;
+        source: &'s S,
+    ) -> Option<ColorsRgbaF32<'s>>;
 
     /// Visits the vertex draw sequence of a primitive.
-    fn indices_u32<S>(&'a self, source: &'a S) -> Option<IndicesU32<'a>>
-        where S: Source;
+    fn indices_u32<'s, S: Source>(&'a self, source: &'s S) -> Option<IndicesU32<'s>>;
 
     /// Visits the joint indices of the primitive.
-    fn joints_u16<S: Source>(&'a self, set: u32, source: &'a S) -> Option<JointsU16<'a>>
-        where S: Source;
+    fn joints_u16<'s, S: Source>(
+        &'a self,
+        set: u32,
+        source: &'s S
+    ) -> Option<JointsU16<'s>>;
 
     /// Visits the joint weights of the primitive.
-    fn weights_f32<S: Source>(&'a self, set: u32, source: &'a S) -> Option<WeightsF32<'a>>
-        where S: Source;
+    fn weights_f32<'s, S: Source>(
+        &'a self,
+        set: u32,
+        source: &'s S
+    ) -> Option<WeightsF32<'s>>;
 }
 
 impl<'a> PrimitiveIterators<'a> for gltf::Primitive<'a> {
-    fn positions<S>(&'a self, source: &'a S) -> Option<Positions<'a>>
-        where S: Source
-    {
+    fn positions<'s, S: Source>(&'a self, source: &'s S) -> Option<Positions<'s>> {
         self.get(&gltf::Semantic::Positions)
             .map(|accessor| Positions(AccessorIter::new(accessor, source)))
     }
 
-    fn normals<S>(&'a self, source: &'a S) -> Option<Normals<'a>>
-        where S: Source
-    {
+    fn normals<'s, S: Source>(&'a self, source: &'s S) -> Option<Normals<'s>> {
         self.get(&gltf::Semantic::Normals)
             .map(|accessor| Normals(AccessorIter::new(accessor, source)))
     }
 
-    fn tangents<S>(&'a self, source: &'a S) -> Option<Tangents<'a>>
-        where S: Source
-    {
+    fn tangents<'s, S: Source>(&'a self, source: &'s S) -> Option<Tangents<'s>> {
         self.get(&gltf::Semantic::Tangents)
             .map(|accessor| Tangents(AccessorIter::new(accessor, source)))
     }
 
-    fn tex_coords_f32<S>(&'a self, set: u32, source: &'a S) -> Option<TexCoordsF32<'a>>
-        where S: Source
-    {
+    fn tex_coords_f32<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<TexCoordsF32<'s>> {
         self.get(&gltf::Semantic::TexCoords(set))
             .map(|accessor| TexCoordsF32(TexCoords::new(accessor, source)))
     }
 
-    fn colors_rgba_f32<S>(
+    fn colors_rgba_f32<'s, S: Source>(
         &'a self,
         set: u32,
         default_alpha: f32,
-        source: &'a S,
-    ) -> Option<ColorsRgbaF32<'a>>
-        where S: Source
-    {
+        source: &'s S,
+    ) -> Option<ColorsRgbaF32<'s>> {
         self.get(&gltf::Semantic::Colors(set))
-            .map(|accessor| {
+            .map(|accessor|
                 ColorsRgbaF32 {
                     iter: Colors::new(accessor, source),
                     default_alpha,
                 }
-            })
+            )
     }
 
-    fn indices_u32<S>(&'a self, source: &'a S) -> Option<IndicesU32<'a>>
-        where S: Source
-    {
+    fn indices_u32<'s, S: Source>(&'a self, source: &'s S) -> Option<IndicesU32<'s>> {
         self.indices().map(|accessor| IndicesU32(Indices::new(accessor, source)))
     }
 
-    fn joints_u16<S>(&'a self, set: u32, source: &'a S) -> Option<JointsU16<'a>>
-        where S: Source
-    {
+    fn joints_u16<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<JointsU16<'s>> {
         self.get(&gltf::Semantic::Joints(set))
             .map(|accessor| JointsU16(Joints::new(accessor, source)))
     }
 
-    fn weights_f32<S>(&'a self, set: u32, source: &'a S) -> Option<WeightsF32<'a>>
-        where S: Source
-    {
+    fn weights_f32<'s, S: Source>(&'a self, set: u32, source: &'s S) -> Option<WeightsF32<'s>> {
         self.get(&gltf::Semantic::Weights(set))
             .map(|accessor| WeightsF32(Weights::new(accessor, source)))
     }
@@ -171,7 +155,7 @@ pub struct AccessorIter<'a, T> {
 }
 
 impl<'a, T> AccessorIter<'a, T> {
-    pub fn new<S>(accessor: gltf::Accessor<'a>, source: &'a S) -> AccessorIter<'a, T>
+    pub fn new<S>(accessor: gltf::Accessor, source: &'a S) -> AccessorIter<'a, T>
         where S: Source
     {
         debug_assert_eq!(size_of::<T>(), accessor.size());
@@ -422,7 +406,7 @@ pub struct ColorsRgbaF32<'a> {
 }
 
 impl<'a> Colors<'a> {
-    fn new<S: Source>(accessor: gltf::Accessor<'a>, source: &'a S) -> Colors<'a> {
+    fn new<S: Source>(accessor: gltf::Accessor, source: &'a S) -> Colors<'a> {
         match (accessor.dimensions(), accessor.data_type()) {
             (Dimensions::Vec3, DataType::U8) => {
                 Colors::RgbU8(AccessorIter::new(accessor, source))
@@ -447,7 +431,7 @@ impl<'a> Colors<'a> {
     }
 }
 impl<'a> TexCoords<'a> {
-    fn new<S: Source>(accessor: gltf::Accessor<'a>, source: &'a S) -> TexCoords<'a> {
+    fn new<S: Source>(accessor: gltf::Accessor, source: &'a S) -> TexCoords<'a> {
         match accessor.data_type() {
             DataType::U8 => TexCoords::U8(AccessorIter::new(accessor, source)),
             DataType::U16 => TexCoords::U16(AccessorIter::new(accessor, source)),
@@ -458,7 +442,7 @@ impl<'a> TexCoords<'a> {
 }
 
 impl<'a> Indices<'a> {
-    fn new<S: Source>(accessor: gltf::Accessor<'a>, source: &'a S) -> Indices<'a> {
+    fn new<S: Source>(accessor: gltf::Accessor, source: &'a S) -> Indices<'a> {
         match accessor.data_type() {
             DataType::U8 => Indices::U8(AccessorIter::new(accessor, source)),
             DataType::U16 => Indices::U16(AccessorIter::new(accessor, source)),
@@ -469,7 +453,7 @@ impl<'a> Indices<'a> {
 }
 
 impl<'a> Joints<'a> {
-    fn new<S: Source>(accessor: gltf::Accessor<'a>, source: &'a S) -> Joints<'a> {
+    fn new<S: Source>(accessor: gltf::Accessor, source: &'a S) -> Joints<'a> {
         match accessor.data_type() {
             DataType::U8 => Joints::U8(AccessorIter::new(accessor, source)),
             DataType::U16 => Joints::U16(AccessorIter::new(accessor, source)),
@@ -479,7 +463,7 @@ impl<'a> Joints<'a> {
 }
 
 impl<'a> Weights<'a> {
-    fn new<S: Source>(accessor: gltf::Accessor<'a>, source: &'a S) -> Weights<'a> {
+    fn new<S: Source>(accessor: gltf::Accessor, source: &'a S) -> Weights<'a> {
         match accessor.data_type() {
             DataType::U8 => Weights::U8(AccessorIter::new(accessor, source)),
             DataType::U16 => Weights::U16(AccessorIter::new(accessor, source)),


### PR DESCRIPTION
This PR makes it possible to do things like:
```rust
let primitives: Vec<_> = mesh.primitives().flat_map(|x| x.positions(&bins)).collect();
```
which would currently be an error because of overly strict lifetime requirements.  This is solved by introducing additional lifetime `'s`, which prevents `'a` from being coerced to shortest common of `PrimitiveIterator` and `Source`.