### PR TITLE
Fix build issues and bug in sparse accessor parsing

### DIFF
--- a/gltf-importer/tests/import_examples.rs
+++ b/gltf-importer/tests/import_examples.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints)]
 extern crate gltf_importer;
 
 use std::{fs, path};

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -121,9 +121,11 @@ pub mod sparse {
         pub component_type: Checked<IndexComponentType>,
 
         /// Extension specific data.
+        #[serde(default)]
         pub extensions: extensions::accessor::sparse::Indices,
 
         /// Optional application specific data.
+        #[serde(default)]
         pub extras: Extras,
     }
 
@@ -147,9 +149,11 @@ pub mod sparse {
         pub values: Values,
 
         /// Extension specific data.
+        #[serde(default)]
         pub extensions: extensions::accessor::sparse::Sparse,
 
         /// Optional application specific data.
+        #[serde(default)]
         pub extras: Extras,
     }
 
@@ -169,9 +173,11 @@ pub mod sparse {
         pub byte_offset: u32,
 
         /// Extension specific data.
+        #[serde(default)]
         pub extensions: extensions::accessor::sparse::Values,
 
         /// Optional application specific data.
+        #[serde(default)]
         pub extras: Extras,
     }
 }


### PR DESCRIPTION
There's a new sample `SimpleSparseAccessor` that failed to import because some optional fields were not marked correctly.
I also fixed the compilation issues as well as I could (without really understanding the related changes.)