### PR TITLE
Fix json chunk padding Glb.to_writer

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -148,7 +148,7 @@ impl<'a> Glb<'a> {
             writer.write_all(&magic[..])?;
             writer.write_all(&self.json)?;
             for _ in 0..padding {
-                writer.write_u8(0)?;
+                writer.write_u8(0x20)?;
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/gltf-rs/gltf/issues/172

Description of the issue copied below.

Glb::to_write pads JSON chunk incorrectly. It uses 0x0, while specification mandates space-characters (0x20)

Quote from specification:

    This chunk must be padded with trailing Space chars (0x20) to satisfy alignment requirements.

https://github.com/gltf-rs/gltf/blob/master/src/binary.rs#L151

Binary buffer, however, is padded correctly

    This chunk must be padded with trailing zeros (0x00) to satisfy alignment requirements.
