### PR TITLE
Do not serialize None

### DIFF
--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -126,6 +126,7 @@ pub mod sparse {
 
         /// Optional application specific data.
         #[serde(default)]
+        #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
         pub extras: Extras,
     }
 
@@ -154,6 +155,7 @@ pub mod sparse {
 
         /// Optional application specific data.
         #[serde(default)]
+        #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
         pub extras: Extras,
     }
 
@@ -178,6 +180,7 @@ pub mod sparse {
 
         /// Optional application specific data.
         #[serde(default)]
+        #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
         pub extras: Extras,
     }
 }
@@ -207,6 +210,7 @@ pub struct Accessor {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 
     /// Specifies if the attribute is a scalar, vector, or matrix.
@@ -219,10 +223,12 @@ pub struct Accessor {
 
     /// Maximum value of each component in this attribute.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max: Option<Value>,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// Specifies whether integer data values should be normalized.
@@ -232,6 +238,7 @@ pub struct Accessor {
     /// Sparse storage of attributes that deviate from their initialization
     /// value.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sparse: Option<sparse::Sparse>,
 }
 

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -81,6 +81,7 @@ pub struct Animation {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// An array of channels, each of which targets an animation's sampler at a
@@ -91,6 +92,7 @@ pub struct Animation {
     
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
     
     /// An array of samplers that combine input and output accessors with an
@@ -114,6 +116,7 @@ pub struct Channel {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -126,6 +129,7 @@ pub struct Target {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// The index of the node to target.
@@ -145,6 +149,7 @@ pub struct Sampler {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// The index of an accessor containing keyframe input values, e.g., time.

--- a/gltf-json/src/asset.rs
+++ b/gltf-json/src/asset.rs
@@ -4,6 +4,7 @@ use {extensions, Extras};
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Asset {
     /// A copyright message suitable for display to credit the content creator.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub copyright: Option<String>,
     
     /// Extension specific data.
@@ -12,13 +13,16 @@ pub struct Asset {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// Tool that generated this glTF model.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub generator: Option<String>,
 
     /// The minimum glTF version that this asset targets.
     #[serde(rename = "minVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_version: Option<String>,
     
     /// The glTF version of this asset.

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -51,10 +51,12 @@ pub struct Buffer {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// The uri of the buffer.  Relative paths are relative to the .gltf file.
     /// Instead of referencing an external file, the uri can also be a data-uri.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uri: Option<String>,
 
     /// Extension specific data.
@@ -63,6 +65,7 @@ pub struct Buffer {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -84,13 +87,16 @@ pub struct View {
     ///
     /// When zero, data is assumed to be tightly packed.
     #[serde(rename = "byteStride")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub byte_stride: Option<ByteStride>,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// Optional target the buffer should be bound to.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<Checked<Target>>,
 
     /// Extension specific data.
@@ -99,6 +105,7 @@ pub struct View {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 

--- a/gltf-json/src/camera.rs
+++ b/gltf-json/src/camera.rs
@@ -27,14 +27,17 @@ pub enum Type {
 pub struct Camera {
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// An orthographic camera containing properties to create an orthographic
     /// projection matrix.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orthographic: Option<Orthographic>,
 
     /// A perspective camera containing properties to create a perspective
     /// projection matrix.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub perspective: Option<Perspective>,
 
     /// Specifies if the camera uses a perspective or orthographic projection.
@@ -47,6 +50,7 @@ pub struct Camera {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -71,6 +75,7 @@ pub struct Orthographic {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -79,12 +84,14 @@ pub struct Orthographic {
 pub struct Perspective {
     /// Aspect ratio of the field of view.
     #[serde(rename = "aspectRatio")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aspect_ratio: Option<f32>,
 
     /// The vertical field of view in radians.
     pub yfov: f32,
 
     /// The distance to the far clipping plane.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zfar: Option<f32>,
 
     /// The distance to the near clipping plane.
@@ -96,6 +103,7 @@ pub struct Perspective {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 

--- a/gltf-json/src/image.rs
+++ b/gltf-json/src/image.rs
@@ -13,19 +13,23 @@ pub struct Image {
     /// The index of the buffer view that contains the image. Use this instead of
     /// the image's uri property.
     #[serde(rename = "bufferView")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub buffer_view: Option<Index<buffer::View>>,
 
     /// The image's MIME type.
     #[serde(rename = "mimeType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<MimeType>,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// The uri of the image.  Relative paths are relative to the .gltf file.
     /// Instead of referencing an external file, the uri can also be a data-uri.
     /// The image format must be jpg or png.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uri: Option<String>,
 
     /// Extension specific data.
@@ -34,6 +38,7 @@ pub struct Image {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -78,6 +78,7 @@ pub struct Material {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// A set of parameter values that are used to define the metallic-roughness
@@ -93,6 +94,7 @@ pub struct Material {
     /// use OpenGL conventions where +X is right and +Y is up. +Z points toward the
     /// viewer.
     #[serde(rename = "normalTexture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub normal_texture: Option<NormalTexture>,
 
     /// The occlusion map texture. The occlusion values are sampled from the R
@@ -101,12 +103,14 @@ pub struct Material {
     /// linear. If other channels are present (GBA), they are ignored for occlusion
     /// calculations.
     #[serde(rename = "occlusionTexture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub occlusion_texture: Option<OcclusionTexture>,
 
     /// The emissive map controls the color and intensity of the light being emitted
     /// by the material. This texture contains RGB components in sRGB color space.
     /// If a fourth component (A) is present, it is ignored.
     #[serde(rename = "emissiveTexture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub emissive_texture: Option<texture::Info>,
 
     /// The emissive color of the material.
@@ -117,6 +121,7 @@ pub struct Material {
     pub extensions: extensions::material::Material,
 
     /// Optional application specific data.
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -131,6 +136,7 @@ pub struct PbrMetallicRoughness {
 
     /// The base color texture.
     #[serde(rename = "baseColorTexture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base_color_texture: Option<texture::Info>,
 
     /// The metalness of the material.
@@ -153,12 +159,14 @@ pub struct PbrMetallicRoughness {
     /// These values are linear. If other channels are present (R or A),
     /// they are ignored for metallic-roughness calculations.
     #[serde(rename = "metallicRoughnessTexture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metallic_roughness_texture: Option<texture::Info>,
 
     /// Extension specific data.
     pub extensions: extensions::material::PbrMetallicRoughness,
 
     /// Optional application specific data.
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -184,6 +192,7 @@ pub struct NormalTexture {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -211,6 +220,7 @@ pub struct OcclusionTexture {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -81,16 +81,19 @@ pub struct Mesh {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// Defines the geometry to be renderered with a material.
     pub primitives: Vec<Primitive>,
 
     /// Defines the weights to be applied to the morph targets.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub weights: Option<Vec<f32>>,
 }
 
@@ -107,12 +110,15 @@ pub struct Primitive {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 
     /// The index of the accessor that contains the indices.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub indices: Option<Index<accessor::Accessor>>,
 
     /// The index of the material to apply to this primitive when rendering
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub material: Option<Index<material::Material>>,
 
     /// The type of primitives to render.
@@ -122,6 +128,7 @@ pub struct Primitive {
     /// An array of Morph Targets, each  Morph Target is a dictionary mapping
     /// attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their
     /// deviations in the Morph Target.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub targets: Option<Vec<MorphTarget>>,
 }
 
@@ -181,14 +188,17 @@ pub struct Primitive {
 pub struct MorphTarget {
     /// XYZ vertex position displacements of type `[f32; 3]`.
     #[serde(rename = "POSITION")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub positions: Option<Index<accessor::Accessor>>,
 
     /// XYZ vertex normal displacements of type `[f32; 3]`.
     #[serde(rename = "NORMAL")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub normals: Option<Index<accessor::Accessor>>,
 
     /// XYZ vertex tangent displacements of type `[f32; 3]`.
     #[serde(rename = "TANGENT")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tangents: Option<Index<accessor::Accessor>>,
 }
 

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -43,6 +43,7 @@ pub struct Root {
     pub buffer_views: Vec<buffer::View>,
 
     /// The default scene.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scene: Option<Index<Scene>>,
 
     /// Extension specific data.
@@ -51,6 +52,7 @@ pub struct Root {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// Names of glTF extensions used somewhere in this asset.

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -14,9 +14,11 @@ use {camera, extensions, mesh, scene, skin, Extras, Index, Root, Path};
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Node {
     /// The index of the camera referenced by this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub camera: Option<Index<camera::Camera>>,
     
     /// The indices of this node's children.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Index<scene::Node>>>,
 
     /// Extension specific data.
@@ -25,16 +27,20 @@ pub struct Node {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// 4x4 column-major transformation matrix.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix: Option<[f32; 16]>,
 
     /// The index of the mesh in this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh: Option<Index<mesh::Mesh>>,
     
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
     
     /// The node's unit quaternion rotation in the order (x, y, z, w), where w is
@@ -51,10 +57,12 @@ pub struct Node {
     pub translation: [f32; 3],
     
     /// The index of the skin referenced by this node.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skin: Option<Index<skin::Skin>>,
     
     /// The weights of the instantiated Morph Target. Number of elements must match
     /// the number of Morph Targets of used mesh.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub weights: Option<Vec<f32>>,
 }
 
@@ -71,10 +79,12 @@ pub struct Scene {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// The indices of each root node.

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -17,7 +17,7 @@ pub struct Skin {
     /// When `None`,each matrix is assumed to be the 4x4 identity matrix
     /// which implies that the inverse-bind matrices were pre-applied.
     #[serde(rename = "inverseBindMatrices")]
-    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub inverse_bind_matrices: Option<Index<accessor::Accessor>>,
     
     /// Indices of skeleton nodes used as joints in this skin.
@@ -34,6 +34,6 @@ pub struct Skin {
     /// The index of the node used as a skeleton root.
     ///
     /// When `None`, joints transforms resolve to scene root.
-    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skeleton: Option<Index<scene::Node>>,
 }

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -9,6 +9,7 @@ pub struct Skin {
     
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
     
     /// The index of the accessor containing the 4x4 inverse-bind matrices.
@@ -16,6 +17,7 @@ pub struct Skin {
     /// When `None`,each matrix is assumed to be the 4x4 identity matrix
     /// which implies that the inverse-bind matrices were pre-applied.
     #[serde(rename = "inverseBindMatrices")]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub inverse_bind_matrices: Option<Index<accessor::Accessor>>,
     
     /// Indices of skeleton nodes used as joints in this skin.
@@ -26,10 +28,12 @@ pub struct Skin {
     
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
     
     /// The index of the node used as a skeleton root.
     ///
     /// When `None`, joints transforms resolve to scene root.
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub skeleton: Option<Index<scene::Node>>,
 }

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -139,14 +139,17 @@ impl WrappingMode {
 pub struct Sampler {
     /// Magnification filter.
     #[serde(rename = "magFilter")]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub mag_filter: Option<Checked<MagFilter>>,
 
     /// Minification filter.
     #[serde(rename = "minFilter")]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub min_filter: Option<Checked<MinFilter>>,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// `s` wrapping mode.
@@ -163,6 +166,7 @@ pub struct Sampler {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -171,9 +175,11 @@ pub struct Sampler {
 pub struct Texture {
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
+    #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
 
     /// The index of the sampler used by this texture.
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub sampler: Option<Index<Sampler>>,
 
     /// The index of the image used by this texture.
@@ -185,6 +191,7 @@ pub struct Texture {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 
@@ -204,6 +211,7 @@ pub struct Info {
 
     /// Optional application specific data.
     #[serde(default)]
+    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
 }
 

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -139,12 +139,12 @@ impl WrappingMode {
 pub struct Sampler {
     /// Magnification filter.
     #[serde(rename = "magFilter")]
-    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mag_filter: Option<Checked<MagFilter>>,
 
     /// Minification filter.
     #[serde(rename = "minFilter")]
-    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_filter: Option<Checked<MinFilter>>,
 
     /// Optional user-defined name for this object.
@@ -179,7 +179,7 @@ pub struct Texture {
     pub name: Option<String>,
 
     /// The index of the sampler used by this texture.
-    #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sampler: Option<Index<Sampler>>,
 
     /// The index of the image used by this texture.


### PR DESCRIPTION
Fixes https://github.com/gltf-rs/gltf/issues/173

After these changes (and the now already merged padding fix) I'm able to open serialized binary glTF files in ThreeJS.

Similarly, all empty vectors **must** be left unserialized, but this PR is about `None`s