### PR TITLE
Skip serializing extras::Void's field

### DIFF
--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -11,9 +11,9 @@ pub type Extras = Option<Value>;
 pub type Extras = Void;
 
 /// Type representing no user-defined data.
-#[derive(Clone, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Default, Serialize, Deserialize, Validate)]
 pub struct Void {
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     _allow_unknown_fields: (),
 }
 


### PR DESCRIPTION
Fixes injection of an extraneous field into generated JSON.

It'd be nice to skip Extras entirely without going through and tediously cfg-ing every use, but I didn't find a way to do that.