### PR TITLE
Allow user code to instantiate the json structure.

### DIFF
--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -182,7 +182,7 @@ impl Root {
 
 impl<T> Index<T> {
     /// Creates a new `Index` representing an offset into an array containing `T`.
-    fn new(value: u32) -> Self {
+    pub fn new(value: u32) -> Self {
         Index(value, std::marker::PhantomData)
     }
 


### PR DESCRIPTION
To in turn enable user code to implement glTF export.

Solves: #189 