### PR TITLE
Changes to support glTF 2.0 export/serialization

### DIFF
--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -232,7 +232,7 @@ pub struct Accessor {
     pub name: Option<String>,
 
     /// Specifies whether integer data values should be normalized.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_normalized_default")]
     pub normalized: bool,
     
     /// Sparse storage of attributes that deviate from their initialization
@@ -240,6 +240,11 @@ pub struct Accessor {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sparse: Option<sparse::Sparse>,
+}
+
+// Help serde avoid serializing this glTF 2.0 default value.
+fn is_normalized_default(b: &bool) -> bool {
+    *b == bool::default()
 }
 
 /// The data type of an index.

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -121,8 +121,8 @@ pub mod sparse {
         pub component_type: Checked<IndexComponentType>,
 
         /// Extension specific data.
-        #[serde(default)]
-        pub extensions: extensions::accessor::sparse::Indices,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub extensions: Option<extensions::accessor::sparse::Indices>,
 
         /// Optional application specific data.
         #[serde(default)]
@@ -150,8 +150,8 @@ pub mod sparse {
         pub values: Values,
 
         /// Extension specific data.
-        #[serde(default)]
-        pub extensions: extensions::accessor::sparse::Sparse,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub extensions: Option<extensions::accessor::sparse::Sparse>,
 
         /// Optional application specific data.
         #[serde(default)]
@@ -175,8 +175,8 @@ pub mod sparse {
         pub byte_offset: u32,
 
         /// Extension specific data.
-        #[serde(default)]
-        pub extensions: extensions::accessor::sparse::Values,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub extensions: Option<extensions::accessor::sparse::Values>,
 
         /// Optional application specific data.
         #[serde(default)]
@@ -205,8 +205,8 @@ pub struct Accessor {
     pub component_type: Checked<GenericComponentType>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::accessor::Accessor,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::accessor::Accessor>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -244,7 +244,7 @@ pub struct Accessor {
 
 // Help serde avoid serializing this glTF 2.0 default value.
 fn is_normalized_default(b: &bool) -> bool {
-    *b == bool::default()
+    !*b
 }
 
 /// The data type of an index.

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -76,8 +76,8 @@ pub enum Property {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Animation {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::animation::Animation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::animation::Animation>,
     
     /// Optional application specific data.
     #[serde(default)]
@@ -113,8 +113,8 @@ pub struct Channel {
     pub target: Target,
     
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::animation::Channel,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::animation::Channel>,
     
     /// Optional application specific data.
     #[serde(default)]
@@ -126,8 +126,8 @@ pub struct Channel {
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Target {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::animation::Target,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::animation::Target>,
     
     /// Optional application specific data.
     #[serde(default)]
@@ -146,8 +146,8 @@ pub struct Target {
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Sampler {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::animation::Sampler,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::animation::Sampler>,
     
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/asset.rs
+++ b/gltf-json/src/asset.rs
@@ -8,8 +8,8 @@ pub struct Asset {
     pub copyright: Option<String>,
     
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::asset::Asset,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::asset::Asset>,
     
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -70,6 +70,9 @@ pub struct Buffer {
 }
 
 /// A view into a buffer generally representing a subset of the buffer.
+///
+/// <https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-bufferview>
+///
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct View {
     /// The parent `Buffer`.
@@ -80,8 +83,8 @@ pub struct View {
     pub byte_length: u32,
 
     /// Offset into the parent buffer in bytes.
-    #[serde(default, rename = "byteOffset")]
-    pub byte_offset: u32,
+    #[serde(default, rename = "byteOffset", skip_serializing_if = "Option::is_none")]
+    pub byte_offset: Option<u32>,
 
     /// The stride in bytes between vertex attributes or other interleavable data.
     ///
@@ -107,6 +110,12 @@ pub struct View {
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
+}
+
+impl View {
+    pub fn byte_offset_default() -> u32 {
+        0
+    }
 }
 
 /// The stride, in bytes, between vertex attributes.

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -60,8 +60,8 @@ pub struct Buffer {
     pub uri: Option<String>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::buffer::Buffer,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::buffer::Buffer>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -100,8 +100,8 @@ pub struct View {
     pub target: Option<Checked<Target>>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::buffer::View,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::buffer::View>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -112,12 +112,6 @@ pub struct View {
     pub extras: Extras,
 }
 
-impl View {
-    pub fn byte_offset_default() -> u32 {
-        0
-    }
-}
-
 /// The stride, in bytes, between vertex attributes.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct ByteStride(pub u32);

--- a/gltf-json/src/camera.rs
+++ b/gltf-json/src/camera.rs
@@ -45,8 +45,8 @@ pub struct Camera {
     pub type_: Checked<Type>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::camera::Camera,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::camera::Camera>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -70,8 +70,8 @@ pub struct Orthographic {
     pub znear: f32,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::camera::Orthographic,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::camera::Orthographic>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -98,8 +98,8 @@ pub struct Perspective {
     pub znear: f32,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::camera::Perspective,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::camera::Perspective>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/image.rs
+++ b/gltf-json/src/image.rs
@@ -33,8 +33,8 @@ pub struct Image {
     pub uri: Option<String>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::image::Image,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::image::Image>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -118,7 +118,8 @@ pub struct Material {
     pub emissive_factor: EmissiveFactor,
 
     /// Extension specific data.
-    pub extensions: extensions::material::Material,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::material::Material>,
 
     /// Optional application specific data.
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
@@ -163,7 +164,8 @@ pub struct PbrMetallicRoughness {
     pub metallic_roughness_texture: Option<texture::Info>,
 
     /// Extension specific data.
-    pub extensions: extensions::material::PbrMetallicRoughness,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::material::PbrMetallicRoughness>,
 
     /// Optional application specific data.
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
@@ -187,8 +189,8 @@ pub struct NormalTexture {
     pub tex_coord: u32,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::material::NormalTexture,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::material::NormalTexture>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -215,8 +217,8 @@ pub struct OcclusionTexture {
     pub tex_coord: u32,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::material::OcclusionTexture,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::material::OcclusionTexture>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -76,8 +76,8 @@ pub enum Mode {
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Mesh {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::mesh::Mesh,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::mesh::Mesh>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -106,8 +106,8 @@ pub struct Primitive {
     pub attributes: HashMap<Checked<Semantic>, Index<accessor::Accessor>>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::mesh::Primitive,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::mesh::Primitive>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -123,7 +123,7 @@ pub struct Primitive {
     pub material: Option<Index<material::Material>>,
 
     /// The type of primitives to render.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_primitive_mode_default")]
     pub mode: Checked<Mode>,
 
     /// An array of Morph Targets, each  Morph Target is a dictionary mapping
@@ -131,6 +131,10 @@ pub struct Primitive {
     /// deviations in the Morph Target.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub targets: Option<Vec<MorphTarget>>,
+}
+
+fn is_primitive_mode_default(mode: &Checked<Mode>) -> bool {
+    *mode == Checked::Valid(Mode::Triangles)
 }
 
     impl Validate for Primitive {

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -51,8 +51,8 @@ pub struct Root {
     pub scene: Option<Index<Scene>>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::root::Root,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::root::Root>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -182,7 +182,7 @@ impl Root {
 
 impl<T> Index<T> {
     /// Creates a new `Index` representing an offset into an array containing `T`.
-    fn new(value: u32) -> Self {
+    pub fn new(value: u32) -> Self {
         Index(value, std::marker::PhantomData)
     }
 

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -22,8 +22,8 @@ pub struct Node {
     pub children: Option<Vec<Index<scene::Node>>>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::scene::Node,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::scene::Node>,
     
     /// Optional application specific data.
     #[serde(default)]
@@ -74,8 +74,8 @@ fn node_scale_default() -> [f32; 3] {
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Scene {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::scene::Scene,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::scene::Scene>,
     
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -31,6 +31,15 @@ pub struct Node {
     pub extras: Extras,
     
     /// 4x4 column-major transformation matrix.
+    ///
+    /// glTF 2.0 specification:
+    ///     When a node is targeted for animation (referenced by an
+    ///     animation.channel.target), only TRS properties may be present;
+    ///     matrix will not be present.
+    /// 
+    /// TODO: Ensure that .matrix is set to None or otherwise skipped during
+    ///       serialization, if the node is targeted for animation.
+    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix: Option<[f32; 16]>,
 
@@ -45,16 +54,16 @@ pub struct Node {
     
     /// The node's unit quaternion rotation in the order (x, y, z, w), where w is
     /// the scalar.
-    #[serde(default)]
-    pub rotation: UnitQuaternion,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation: Option<UnitQuaternion>,
 
     /// The node's non-uniform scale.
-    #[serde(default = "node_scale_default")]
-    pub scale: [f32; 3],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale: Option<[f32; 3]>,
 
     /// The node's translation.
-    #[serde(default)]
-    pub translation: [f32; 3],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub translation: Option<[f32; 3]>,
     
     /// The index of the skin referenced by this node.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -66,8 +75,18 @@ pub struct Node {
     pub weights: Option<Vec<f32>>,
 }
 
-fn node_scale_default() -> [f32; 3] {
-    [1.0, 1.0, 1.0]
+impl Node {
+    pub fn translation_default() -> [f32; 3] {
+        [0.0, 0.0, 0.0]
+    }
+
+    pub fn rotation_default() -> UnitQuaternion {
+        UnitQuaternion::default()
+    }
+
+    pub fn scale_default() -> [f32; 3] {
+        [1.0, 1.0, 1.0]
+    }
 }
 
 /// The root `Node`s of a scene.

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -75,20 +75,6 @@ pub struct Node {
     pub weights: Option<Vec<f32>>,
 }
 
-impl Node {
-    pub fn translation_default() -> [f32; 3] {
-        [0.0, 0.0, 0.0]
-    }
-
-    pub fn rotation_default() -> UnitQuaternion {
-        UnitQuaternion::default()
-    }
-
-    pub fn scale_default() -> [f32; 3] {
-        [1.0, 1.0, 1.0]
-    }
-}
-
 /// The root `Node`s of a scene.
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Scene {

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -4,8 +4,8 @@ use {accessor, extensions, scene, Extras, Index};
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
 pub struct Skin {
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::skin::Skin,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::skin::Skin>,
     
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -161,8 +161,8 @@ pub struct Sampler {
     pub wrap_t: Checked<WrappingMode>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::texture::Sampler,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::texture::Sampler>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -186,8 +186,8 @@ pub struct Texture {
     pub source: Index<image::Image>,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::texture::Texture,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::texture::Texture>,
 
     /// Optional application specific data.
     #[serde(default)]
@@ -206,8 +206,8 @@ pub struct Info {
     pub tex_coord: u32,
 
     /// Extension specific data.
-    #[serde(default)]
-    pub extensions: extensions::texture::Info,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<extensions::texture::Info>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -137,7 +137,8 @@ impl<'a> View<'a> {
 
     /// Returns the offset into the parent buffer in bytes.
     pub fn offset(&self) -> usize {
-        self.json.byte_offset as usize
+        self.json.byte_offset.unwrap_or_else(
+            json::buffer::View::byte_offset_default) as usize
     }
 
     /// Returns the stride in bytes between vertex attributes or other interleavable

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -137,8 +137,7 @@ impl<'a> View<'a> {
 
     /// Returns the offset into the parent buffer in bytes.
     pub fn offset(&self) -> usize {
-        self.json.byte_offset.unwrap_or_else(
-            json::buffer::View::byte_offset_default) as usize
+        self.json.byte_offset.unwrap_or(0) as usize
     }
 
     /// Returns the stride in bytes between vertex attributes or other interleavable

--- a/src/material.rs
+++ b/src/material.rs
@@ -96,7 +96,10 @@ impl<'a> Material<'a> {
     /// Physically-Based Rendering (PBR) methodology.
     #[cfg(feature = "KHR_materials_pbrSpecularGlossiness")]
     pub fn pbr_specular_glossiness(&self) -> Option<PbrSpecularGlossiness<'a>> {
-        self.json.extensions.pbr_specular_glossiness.as_ref().map(|x| PbrSpecularGlossiness::new(self.document, x))
+        self.json.extensions
+            .as_ref()?
+            .pbr_specular_glossiness.as_ref()
+            .map(|x| PbrSpecularGlossiness::new(self.document, x))
     }
 
     /// A tangent space normal map.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -176,9 +176,12 @@ impl<'a> Node<'a> {
             }
         } else {
             Transform::Decomposed {
-                translation: self.json.translation,
-                rotation: self.json.rotation.0,
-                scale: self.json.scale,
+                translation: self.json.translation.unwrap_or_else(
+                    json::Node::translation_default),
+                rotation: self.json.rotation.unwrap_or_else(
+                    json::Node::rotation_default).0,
+                scale: self.json.scale.unwrap_or_else(
+                    json::Node::scale_default),
             }
         }
     }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -176,12 +176,12 @@ impl<'a> Node<'a> {
             }
         } else {
             Transform::Decomposed {
-                translation: self.json.translation.unwrap_or_else(
-                    json::Node::translation_default),
-                rotation: self.json.rotation.unwrap_or_else(
-                    json::Node::rotation_default).0,
-                scale: self.json.scale.unwrap_or_else(
-                    json::Node::scale_default),
+                translation: self.json.translation
+                    .unwrap_or_else(|| [0.0, 0.0, 0.0]),
+                rotation: self.json.rotation
+                    .unwrap_or_else(json::scene::UnitQuaternion::default).0,
+                scale: self.json.scale
+                    .unwrap_or_else(|| [1.0, 1.0, 1.0]),
             }
         }
     }


### PR DESCRIPTION
Solves: #189 

Please see the commit messages for the details related to each commit.

Some background:
I'm implementing glTF 2.0 export based on this crate, not export of imported data, export of in-process generated assets. This requires all related data structures to be correctly instantiated by user code. I have also made optional json properties optional and added `serde(skip_serializing_if` attributes for some simple default values. This helps to verify that my test output is identical to the reference models provided by Khronos. The TRS properties also must be made optional to follow the specification, please see the commit messages and links to the related sections of the spec.

I have started to implement some builders to make export easier, that aren't ready yet, but I would like to upstream them as well at a later time, they do depend on this PR.

If you would like me to make further changes or go about this in a completely different way, please tell me :slightly_smiling_face: 