### PR TITLE
Small JSON fixes

### DIFF
--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -218,12 +218,11 @@ pub struct Accessor {
     pub type_: Checked<Type>,
 
     /// Minimum value of each component in this attribute.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min: Option<Value>,
 
     /// Maximum value of each component in this attribute.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max: Option<Value>,
 
     /// Optional user-defined name for this object.

--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -13,7 +13,7 @@ pub type Extras = Void;
 /// Type representing no user-defined data.
 #[derive(Clone, Default, Deserialize, Serialize, Validate)]
 pub struct Void {
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     _allow_unknown_fields: (),
 }
 

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -182,7 +182,7 @@ impl Root {
 
 impl<T> Index<T> {
     /// Creates a new `Index` representing an offset into an array containing `T`.
-    fn new(value: u32) -> Self {
+    pub fn new(value: u32) -> Self {
         Index(value, std::marker::PhantomData)
     }
 


### PR DESCRIPTION
* Add 'serialize-if-not-none' attribute to `Accessor::min`.
* Add 'serialize-if-not-none' attribute to `Extras::_allow_unknown_fields`.
* Make `Index::new` public.