### PR TITLE
Fix assert on meshes on byte_stride = 0

### DIFF
--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -93,7 +93,7 @@ impl<'a, T> Iter<'a, T> {
         debug_assert!(mem::size_of::<T>() > 0);
         let view = accessor.view();
         let stride = view.stride().unwrap_or(mem::size_of::<T>());
-        debug_assert!(stride >= mem::size_of::<T>());
+        debug_assert!(stride >= mem::size_of::<T>(), "Mismatch in stride, expected at least {} stride but found {}", mem::size_of::<T>(), stride);
         let start = view.offset() + accessor.offset();
         let end = start + stride * (accessor.count() - 1) + mem::size_of::<T>();
         let data = &buffer_data[start .. end];

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -143,7 +143,15 @@ impl<'a> View<'a> {
     /// Returns the stride in bytes between vertex attributes or other interleavable
     /// data. When `None`, data is assumed to be tightly packed.
     pub fn stride(&self) -> Option<usize> {
-        self.json.byte_stride.map(|x| x.0 as usize)
+        self.json.byte_stride.and_then(|x| {
+                // Treat byte_stride == 0 same as not specifying stride.
+                // This is technically a validation error, but best way we can handle it here
+                if x.0 == 0 {
+                    None
+                } else {
+                    Some(x.0 as usize)  
+                }
+            })
     }
 
     /// Optional user-defined name for this object.


### PR DESCRIPTION
Have found glTF meshes (on Google Poly) that specify 0 byte stride for index buffers which caused debug_assert to be triggered on 0 byte stride when calling `read_indices`.

This should already fail validation, but only the case of `validation_completely` which is typically not run.

With this change we specifically handle the case of byte stride 0 and treat it as if no byte stride was specified to avoid the debug assert and panicking. 