### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["glTF", "3D", "asset", "model", "scene"]
 license = "MIT/Apache-2.0"
 include = ["**/*.rs", "Cargo.toml"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "gltf-rs/gltf" }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 This crate is intended to load [glTF 2.0](https://www.khronos.org/gltf), a file format designed for the efficient transmission of 3D assets.
 
-`rustc` version 1.19 or above is required; version 1.26 and above is recommended.
+`rustc` version 1.32 or above is required.
 
 ### Reference infographic
 

--- a/examples/display/main.rs
+++ b/examples/display/main.rs
@@ -1,5 +1,3 @@
-extern crate gltf;
-
 use std::{fs, io};
 
 use std::boxed::Box;

--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -1,5 +1,4 @@
-extern crate gltf;
-extern crate gltf_json as json;
+use gltf_json as json;
 
 use std::{fs, mem};
 

--- a/examples/tree/main.rs
+++ b/examples/tree/main.rs
@@ -1,5 +1,3 @@
-extern crate gltf;
-
 use std::{fs, io};
 use std::boxed::Box;
 use std::error::Error as StdError;
@@ -9,7 +7,7 @@ fn print_tree(node: &gltf::Node, depth: i32) {
         print!("  ");
     }
     print!(" -");
-    print!(" Node {}", node.index());   
+    print!(" Node {}", node.index());
     #[cfg(feature = "names")]
     print!(" ({})", node.name().unwrap_or("<Unnamed>"));
     println!();

--- a/gltf-derive/Cargo.toml
+++ b/gltf-derive/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Harvey-Macaulay <alteous@outlook.com>"]
 description = "Internal macros for the gltf crate"
 repository = "https://github.com/gltf-rs/gltf"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/gltf-derive/src/lib.rs
+++ b/gltf-derive/src/lib.rs
@@ -4,16 +4,14 @@
 
 #![recursion_limit = "128"]
 
-extern crate inflections;
 #[macro_use]
 extern crate quote;
 extern crate proc_macro;
-extern crate syn;
 
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(Validate)]
-pub fn main(input: TokenStream) -> TokenStream {
+pub fn derive_validate(input: TokenStream) -> TokenStream {
     let source = input.to_string();
     let ast = syn::parse_macro_input(&source).unwrap();
     let tokens = expand(&ast);
@@ -56,17 +54,17 @@ fn expand(ast: &syn::MacroInput) -> quote::Tokens {
         .collect();
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     quote!(
-        impl #impl_generics ::validation::Validate
+        impl #impl_generics crate::validation::Validate
             for #ident #ty_generics #where_clause
         {
             fn validate_minimally<P, R>(
                 &self,
-                _root: &::Root,
+                _root: &crate::Root,
                 _path: P,
                 _report: &mut R
             ) where
-                P: Fn() -> ::Path,
-                R: FnMut(&Fn() -> ::Path, ::validation::Error),
+                P: Fn() -> crate::Path,
+                R: FnMut(&Fn() -> crate::Path, crate::validation::Error),
             {
                 #(
                     #minimal_validations;
@@ -75,12 +73,12 @@ fn expand(ast: &syn::MacroInput) -> quote::Tokens {
 
             fn validate_completely<P, R>(
                 &self,
-                _root: &::Root,
+                _root: &crate::Root,
                 _path: P,
                 _report: &mut R
             ) where
-                P: Fn() -> ::Path,
-                R: FnMut(&Fn() -> ::Path, ::validation::Error),
+                P: Fn() -> crate::Path,
+                R: FnMut(&Fn() -> crate::Path, crate::validation::Error),
             {
                 #(
                     #complete_validations;

--- a/gltf-json/Cargo.toml
+++ b/gltf-json/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Harvey-Macaulay <alteous@outlook.com>"]
 description = "JSON parsing for the gltf crate"
 repository = "https://github.com/gltf-rs/gltf"
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 gltf-derive = { path = "../gltf-derive", version = "0.11.3" }

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -1,8 +1,10 @@
-use {buffer, extensions, Extras, Index};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::{buffer, extensions, Extras, Index};
 use serde::{de, ser};
 use serde_json::Value;
 use std::fmt;
-use validation::Checked;
+use crate::validation::Checked;
 
 /// The component data type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
@@ -100,7 +102,7 @@ pub const VALID_ACCESSOR_TYPES: &'static [&'static str] = &[
 /// Contains data structures for sparse storage.
 pub mod sparse {
     use super::*;
-    use ::extensions;
+    use crate::extensions;
 
     /// Indices of those attributes that deviate from their initialization value.
     #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
@@ -270,7 +272,7 @@ impl<'de> de::Deserialize<'de> for Checked<GenericComponentType> {
                 where E: de::Error
             {
                 use self::ComponentType::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     BYTE => Valid(GenericComponentType(I8)),
                     UNSIGNED_BYTE => Valid(GenericComponentType(U8)),
@@ -302,7 +304,7 @@ impl<'de> de::Deserialize<'de> for Checked<IndexComponentType> {
                 where E: de::Error
             {
                 use self::ComponentType::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     UNSIGNED_BYTE => Valid(IndexComponentType(U8)),
                     UNSIGNED_SHORT => Valid(IndexComponentType(U16)),
@@ -331,7 +333,7 @@ impl<'de> de::Deserialize<'de> for Checked<Type> {
                 where E: de::Error
             {
                 use self::Type::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value {
                     "SCALAR" => Valid(Scalar),
                     "VEC2" => Valid(Vec2),

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -1,7 +1,9 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use serde::{de, ser};
 use std::fmt;
-use validation::{Checked, Error, Validate};
-use {accessor, extensions, scene, Extras, Index, Path, Root};
+use crate::validation::{Checked, Error, Validate};
+use crate::{accessor, extensions, scene, Extras, Index, Path, Root};
 
 /// All valid animation interpolation algorithms.
 pub const VALID_INTERPOLATIONS: &'static [&'static str] = &[
@@ -203,7 +205,7 @@ impl<'de> de::Deserialize<'de> for Checked<Interpolation> {
                 where E: de::Error
             {
                 use self::Interpolation::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value {
                     "LINEAR" => Valid(Linear),
                     "STEP" => Valid(Step),
@@ -247,7 +249,7 @@ impl<'de> de::Deserialize<'de> for Checked<Property> {
                 where E: de::Error
             {
                 use self::Property::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value {
                     "translation" => Valid(Translation),
                     "rotation" => Valid(Rotation),

--- a/gltf-json/src/asset.rs
+++ b/gltf-json/src/asset.rs
@@ -1,4 +1,6 @@
-use {extensions, Extras};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::{extensions, Extras};
 
 /// Metadata about the glTF asset.
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
@@ -6,16 +8,16 @@ pub struct Asset {
     /// A copyright message suitable for display to credit the content creator.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub copyright: Option<String>,
-    
+
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<extensions::asset::Asset>,
-    
+
     /// Optional application specific data.
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
-    
+
     /// Tool that generated this glTF model.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generator: Option<String>,
@@ -24,7 +26,7 @@ pub struct Asset {
     #[serde(rename = "minVersion")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_version: Option<String>,
-    
+
     /// The glTF version of this asset.
     pub version: String,
 }

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -1,7 +1,9 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use serde::{de, ser};
 use std::fmt;
-use validation::{Checked, Error, Validate};
-use {extensions, Extras, Index, Root, Path};
+use crate::validation::{Checked, Error, Validate};
+use crate::{extensions, Extras, Index, Root, Path};
 
 /// Corresponds to `GL_ARRAY_BUFFER`.
 pub const ARRAY_BUFFER: u32 = 34_962;
@@ -149,7 +151,7 @@ impl<'de> de::Deserialize<'de> for Checked<Target> {
                 where E: de::Error
             {
                 use self::Target::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     ARRAY_BUFFER => Valid(ArrayBuffer),
                     ELEMENT_ARRAY_BUFFER => Valid(ElementArrayBuffer),

--- a/gltf-json/src/camera.rs
+++ b/gltf-json/src/camera.rs
@@ -1,7 +1,8 @@
 use serde::{de, ser};
+use serde_derive::{Serialize, Deserialize};
 use std::fmt;
-use validation::{Checked, Error, Validate};
-use {extensions, Extras, Root, Path};
+use crate::validation::{Checked, Error, Validate};
+use crate::{extensions, Extras, Root, Path};
 
 /// All valid camera types.
 pub const VALID_CAMERA_TYPES: &'static [&'static str] = &[
@@ -194,7 +195,7 @@ impl<'de> de::Deserialize<'de> for Checked<Type> {
                 where E: de::Error
             {
                 use self::Type::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value {
                     "perspective" => Valid(Perspective),
                     "orthographic" => Valid(Orthographic),

--- a/gltf-json/src/extensions/accessor.rs
+++ b/gltf-json/src/extensions/accessor.rs
@@ -1,5 +1,10 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// Contains data structures for sparse storage.
 pub mod sparse {
+    use super::*;
+
     /// Indices of those attributes that deviate from their initialization value.
     #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
     pub struct Indices {}

--- a/gltf-json/src/extensions/animation.rs
+++ b/gltf-json/src/extensions/animation.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// A keyframe animation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Animation {}

--- a/gltf-json/src/extensions/asset.rs
+++ b/gltf-json/src/extensions/asset.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// Metadata about the glTF asset.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Asset {}

--- a/gltf-json/src/extensions/buffer.rs
+++ b/gltf-json/src/extensions/buffer.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// A buffer points to binary data representing geometry, animations, or skins.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Buffer {}

--- a/gltf-json/src/extensions/camera.rs
+++ b/gltf-json/src/extensions/camera.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// A camera's projection.
 ///
 /// A node can reference a camera to apply a transform to place the camera in the

--- a/gltf-json/src/extensions/image.rs
+++ b/gltf-json/src/extensions/image.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// Image data used to create a texture.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Image {}

--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -1,6 +1,7 @@
-use validation::{Error, Validate};
-use material::StrengthFactor;
-use {texture, Extras, Root, Path};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::{Extras, Path, Root, texture, validation::Error,
+validation::Validate, material::StrengthFactor};
 
 /// The material appearance of a primitive.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]

--- a/gltf-json/src/extensions/mesh.rs
+++ b/gltf-json/src/extensions/mesh.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// A set of primitives to be rendered.
 ///
 /// A node can contain one or more meshes and its transform places the meshes in

--- a/gltf-json/src/extensions/root.rs
+++ b/gltf-json/src/extensions/root.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// The root object of a glTF 2.0 asset.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Root {}

--- a/gltf-json/src/extensions/scene.rs
+++ b/gltf-json/src/extensions/scene.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// A node in the node hierarchy.  When the node contains `skin`, all
 /// `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.
 /// A node can have either a `matrix` or any combination of

--- a/gltf-json/src/extensions/skin.rs
+++ b/gltf-json/src/extensions/skin.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// Joints and matrices defining a skin.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Skin {}

--- a/gltf-json/src/extensions/texture.rs
+++ b/gltf-json/src/extensions/texture.rs
@@ -1,3 +1,6 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+
 /// Texture sampler properties for filtering and wrapping modes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Sampler {}

--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -1,11 +1,13 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use std::fmt;
 
 #[cfg(feature = "extras")]
-use ::{Path, Root};
+use crate::{Path, Root};
 #[cfg(feature = "extras")]
 pub use serde_json::value::RawValue;
 #[cfg(feature = "extras")]
-use validation::{Error, Validate};
+use crate::validation::{Error, Validate};
 
 /// Data type of the `extras` attribute on all glTF objects.
 #[cfg(feature = "extras")]

--- a/gltf-json/src/image.rs
+++ b/gltf-json/src/image.rs
@@ -1,5 +1,7 @@
-use validation::{Error, Validate};
-use {buffer, extensions, Extras, Index, Root, Path};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::validation::{Error, Validate};
+use crate::{buffer, extensions, Extras, Index, Root, Path};
 
 /// All valid MIME types.
 pub const VALID_MIME_TYPES: &'static [&'static str] = &[

--- a/gltf-json/src/lib.rs
+++ b/gltf-json/src/lib.rs
@@ -1,10 +1,3 @@
-#[macro_use]
-extern crate gltf_derive;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
 /// Contains `Accessor` and other related data structures.
 pub mod accessor;
 

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -1,7 +1,9 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use serde::{de, ser};
 use std::fmt;
-use validation::{Checked, Error, Validate};
-use {extensions, texture, Extras, Index, Root, Path};
+use crate::validation::{Checked, Error, Validate};
+use crate::{extensions, texture, Extras, Index, Root, Path};
 
 /// All valid alpha modes.
 pub const VALID_ALPHA_MODES: &'static [&'static str] = &[
@@ -280,7 +282,7 @@ impl<'de> de::Deserialize<'de> for Checked<AlphaMode> {
                 where E: de::Error
             {
                 use self::AlphaMode::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value {
                     "OPAQUE" => Valid(Opaque),
                     "MASK" => Valid(Mask),

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -1,9 +1,11 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use serde::{de, ser};
 use serde_json::from_value;
 use std::collections::HashMap;
 use std::fmt;
-use validation::{Checked, Error, Validate};
-use {accessor, extensions, material, Extras, Index};
+use crate::validation::{Checked, Error, Validate};
+use crate::{accessor, extensions, material, Extras, Index};
 
 /// Corresponds to `GL_POINTS`.
 pub const POINTS: u32 = 0;
@@ -138,10 +140,10 @@ fn is_primitive_mode_default(mode: &Checked<Mode>) -> bool {
 }
 
     impl Validate for Primitive {
-        fn validate_minimally<P, R>(&self, root: &::Root, path: P, report: &mut R)
+        fn validate_minimally<P, R>(&self, root: &crate::Root, path: P, report: &mut R)
         where
-            P: Fn() -> ::Path,
-            R: FnMut(&Fn() -> ::Path, ::validation::Error),
+            P: Fn() -> crate::Path,
+            R: FnMut(&Fn() -> crate::Path, crate::validation::Error),
         {
             // Generated part
             self.attributes
@@ -274,7 +276,7 @@ impl<'de> de::Deserialize<'de> for Checked<Mode> {
                 where E: de::Error
             {
                 use self::Mode::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     POINTS => Valid(Points),
                     LINES => Valid(Lines),
@@ -303,7 +305,7 @@ impl ser::Serialize for Mode {
 impl Semantic {
     fn checked(s: &str) -> Checked<Self> {
         use self::Semantic::*;
-        use validation::Checked::*;
+        use crate::validation::Checked::*;
         match s {
             "NORMAL" => Valid(Normals),
             "POSITION" => Valid(Positions),

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -1,14 +1,14 @@
-use buffer;
-use extensions;
-use serde;
-use serde_json;
+use gltf_derive::Validate;
+use crate::buffer;
+use crate::extensions;
+use serde_derive::{Serialize, Deserialize};
 use std::{self, fmt, io, marker};
-use texture;
-use validation;
+use crate::texture;
+use crate::validation;
 
-use path::Path;
+use crate::path::Path;
 use validation::Validate;
-use {Accessor, Animation, Asset, Buffer, Camera, Error, Extras, Image, Material, Mesh, Node, Scene, Skin, Texture, Value};
+use crate::{Accessor, Animation, Asset, Buffer, Camera, Error, Extras, Image, Material, Mesh, Node, Scene, Skin, Texture, Value};
 
 /// Helper trait for retrieving top-level objects by a universal identifier.
 pub trait Get<T> {
@@ -27,7 +27,7 @@ pub struct Root {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub accessors: Vec<Accessor>,
-    
+
     /// An array of keyframe animations.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -35,12 +35,12 @@ pub struct Root {
 
     /// Metadata about the glTF asset.
     pub asset: Asset,
-    
+
     /// An array of buffers.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub buffers: Vec<Buffer>,
-    
+
     /// An array of buffer views.
     #[serde(default, rename = "bufferViews")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -58,7 +58,7 @@ pub struct Root {
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
-    
+
     /// Names of glTF extensions used somewhere in this asset.
     #[serde(default, rename = "extensionsUsed")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -68,47 +68,47 @@ pub struct Root {
     #[serde(default, rename = "extensionsRequired")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extensions_required: Vec<String>,
-    
+
     /// An array of cameras.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cameras: Vec<Camera>,
-    
+
     /// An array of images.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub images: Vec<Image>,
-    
+
     /// An array of materials.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub materials: Vec<Material>,
-    
+
     /// An array of meshes.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub meshes: Vec<Mesh>,
-    
+
     /// An array of nodes.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub nodes: Vec<Node>,
-    
+
     /// An array of samplers.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub samplers: Vec<texture::Sampler>,
-    
+
     /// An array of scenes.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub scenes: Vec<Scene>,
-    
+
     /// An array of skins.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub skins: Vec<Skin>,
-    
+
     /// An array of textures.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -1,5 +1,7 @@
-use validation::{Error, Validate};
-use {camera, extensions, mesh, scene, skin, Extras, Index, Root, Path};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::validation::{Error, Validate};
+use crate::{camera, extensions, mesh, scene, skin, Extras, Index, Root, Path};
 
 /// A node in the node hierarchy.  When the node contains `skin`, all
 /// `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.
@@ -16,7 +18,7 @@ pub struct Node {
     /// The index of the camera referenced by this node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub camera: Option<Index<camera::Camera>>,
-    
+
     /// The indices of this node's children.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<Index<scene::Node>>>,
@@ -24,19 +26,19 @@ pub struct Node {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<extensions::scene::Node>,
-    
+
     /// Optional application specific data.
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
-    
+
     /// 4x4 column-major transformation matrix.
     ///
     /// glTF 2.0 specification:
     ///     When a node is targeted for animation (referenced by an
     ///     animation.channel.target), only TRS properties may be present;
     ///     matrix will not be present.
-    /// 
+    ///
     /// TODO: Ensure that .matrix is set to None or otherwise skipped during
     ///       serialization, if the node is targeted for animation.
     ///
@@ -46,12 +48,12 @@ pub struct Node {
     /// The index of the mesh in this node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh: Option<Index<mesh::Mesh>>,
-    
+
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
     #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
-    
+
     /// The node's unit quaternion rotation in the order (x, y, z, w), where w is
     /// the scalar.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,11 +66,11 @@ pub struct Node {
     /// The node's translation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub translation: Option<[f32; 3]>,
-    
+
     /// The index of the skin referenced by this node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub skin: Option<Index<skin::Skin>>,
-    
+
     /// The weights of the instantiated Morph Target. Number of elements must match
     /// the number of Morph Targets of used mesh.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,12 +83,12 @@ pub struct Scene {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<extensions::scene::Scene>,
-    
+
     /// Optional application specific data.
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
-    
+
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
     #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -1,4 +1,6 @@
-use {accessor, extensions, scene, Extras, Index};
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
+use crate::{accessor, extensions, scene, Extras, Index};
 
 /// Joints and matrices defining a skin.
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
@@ -6,12 +8,12 @@ pub struct Skin {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<extensions::skin::Skin>,
-    
+
     /// Optional application specific data.
     #[serde(default)]
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     pub extras: Extras,
-    
+
     /// The index of the accessor containing the 4x4 inverse-bind matrices.
     ///
     /// When `None`,each matrix is assumed to be the 4x4 identity matrix
@@ -19,19 +21,19 @@ pub struct Skin {
     #[serde(rename = "inverseBindMatrices")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inverse_bind_matrices: Option<Index<accessor::Accessor>>,
-    
+
     /// Indices of skeleton nodes used as joints in this skin.
     ///
     /// The array length must be the same as the `count` property of the
     /// `inverse_bind_matrices` `Accessor` (when defined).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub joints: Vec<Index<scene::Node>>,
-    
+
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
     #[cfg_attr(feature = "names", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<String>,
-    
+
     /// The index of the node used as a skeleton root.
     ///
     /// When `None`, joints transforms resolve to scene root.

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -1,7 +1,9 @@
+use gltf_derive::Validate;
+use serde_derive::{Serialize, Deserialize};
 use serde::{de, ser};
 use std::fmt;
-use validation::Checked;
-use {extensions, image, Extras, Index};
+use crate::validation::Checked;
+use crate::{extensions, image, Extras, Index};
 
 /// Corresponds to `GL_NEAREST`.
 pub const NEAREST: u32 = 9728;
@@ -231,7 +233,7 @@ impl<'de> de::Deserialize<'de> for Checked<MagFilter> {
                 where E: de::Error
             {
                 use self::MagFilter::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     NEAREST => Valid(Nearest),
                     LINEAR => Valid(Linear),
@@ -259,7 +261,7 @@ impl<'de> de::Deserialize<'de> for Checked<MinFilter> {
                 where E: de::Error
             {
                 use self::MinFilter::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     NEAREST => Valid(Nearest),
                     LINEAR => Valid(Linear),
@@ -300,7 +302,7 @@ impl<'de> de::Deserialize<'de> for Checked<WrappingMode> {
                 where E: de::Error
             {
                 use self::WrappingMode::*;
-                use validation::Checked::*;
+                use crate::validation::Checked::*;
                 Ok(match value as u32 {
                     CLAMP_TO_EDGE => Valid(ClampToEdge),
                     MIRRORED_REPEAT => Valid(MirroredRepeat),

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -1,12 +1,8 @@
-use serde::ser;
-use serde_json;
-use std;
-
-use serde::{Serialize, Serializer};
+use serde::{ser, Serialize, Serializer};
 use std::collections::HashMap;
 use std::hash::Hash;
 
-use {Path, Root};
+use crate::{Path, Root};
 
 /// Trait for validating glTF JSON data against the 2.0 specification.
 pub trait Validate {

--- a/gltf-json/tests/test_validation.rs
+++ b/gltf-json/tests/test_validation.rs
@@ -1,6 +1,5 @@
 use std::{fs, io};
 
-extern crate gltf_json;
 use gltf_json::validation::{Validate, Error};
 use gltf_json::Path;
 

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -56,9 +56,7 @@
 //! # }
 //! ```
 
-use {buffer, json};
-
-use Document;
+use crate::{buffer, Document};
 
 pub use json::accessor::ComponentType as DataType;
 pub use json::accessor::Type as Dimensions;

--- a/src/accessor/sparse.rs
+++ b/src/accessor/sparse.rs
@@ -1,5 +1,4 @@
-use Document;
-use {buffer, json};
+use crate::{buffer, Document};
 
 /// The index data type.
 #[derive(Clone, Debug)]

--- a/src/animation/iter.rs
+++ b/src/animation/iter.rs
@@ -1,7 +1,6 @@
-use json;
 use std::slice;
 
-use animation::{Animation, Channel, Sampler};
+use crate::animation::{Animation, Channel, Sampler};
 
 /// An `Iterator` that visits the channels of an animation.
 #[derive(Clone, Debug)]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -1,7 +1,7 @@
-use {accessor, json, scene, Document};
+use crate::{accessor, scene, Document};
 
 #[cfg(feature = "utils")]
-use Buffer;
+use crate::Buffer;
 
 pub use json::animation::{Interpolation, Property};
 

--- a/src/animation/util/mod.rs
+++ b/src/animation/util/mod.rs
@@ -4,10 +4,10 @@ pub mod rotations;
 /// Casting iterator adapters for morph target weights.
 pub mod morph_target_weights;
 
-use accessor;
+use crate::accessor;
 
-use animation::Channel;
-use Buffer;
+use crate::animation::Channel;
+use crate::Buffer;
 
 /// Animation input sampler values of type `f32`.
 pub type ReadInputs<'a> = accessor::Iter<'a, f32>;
@@ -152,7 +152,7 @@ where F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
     /// Visits the output samples of a channel.
     pub fn read_outputs(&self) -> Option<ReadOutputs<'s>> {
         use accessor::{DataType, Iter};
-        use animation::Property;
+        use crate::animation::Property;
 
         let output = self.channel.sampler().output();
         if let Some(slice) = (self.get_buffer_data)(output.view().buffer()) {
@@ -177,7 +177,7 @@ where F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
                         _ => unreachable!()
                     }),
                 }
-            )            
+            )
         } else {
             None
         }

--- a/src/animation/util/morph_target_weights.rs
+++ b/src/animation/util/morph_target_weights.rs
@@ -1,6 +1,6 @@
-use animation::util::MorphTargetWeights;
+use super::MorphTargetWeights;
 use std::marker::PhantomData;
-use Normalize;
+use crate::Normalize;
 
 /// Casting iterator for `MorphTargetWeights`.
 #[derive(Clone, Debug)]

--- a/src/animation/util/rotations.rs
+++ b/src/animation/util/rotations.rs
@@ -1,6 +1,6 @@
-use animation::util::Rotations;
+use super::Rotations;
 use std::marker::PhantomData;
-use Normalize;
+use crate::Normalize;
 
 /// Casting iterator for `Rotations`.
 #[derive(Clone, Debug)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,9 +1,7 @@
-use json;
-
 #[cfg(feature = "import")]
 use std::ops;
 
-use {Document};
+use crate::Document;
 
 pub use json::buffer::Target;
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,4 @@
-use {json, Document};
+use crate::Document;
 
 /// A camera's projection.
 #[derive(Clone, Debug)]
@@ -23,7 +23,7 @@ pub struct Camera<'a> {
     /// The corresponding JSON struct.
     json: &'a json::camera::Camera,
 }
-  
+
 ///  Values for an orthographic camera projection.
 #[derive(Clone, Debug)]
 pub struct Orthographic<'a> {
@@ -33,7 +33,7 @@ pub struct Orthographic<'a> {
     /// The corresponding JSON struct.
     json: &'a json::camera::Orthographic,
 }
-  
+
 /// Values for a perspective camera projection.
 #[derive(Clone, Debug)]
 pub struct Perspective<'a> {
@@ -77,7 +77,7 @@ impl<'a> Camera<'a> {
                 Projection::Perspective(Perspective::new(self.document, json))
             },
         }
-    } 
+    }
 
     /// Optional application specific data.
     pub fn extras(&self) -> &json::Extras {

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,4 @@
-use {buffer, json};
-use Document;
+use crate::{buffer, Document};
 
 #[cfg(feature = "import")]
 use image_crate::DynamicImage;

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,12 +1,11 @@
 use base64;
-use buffer;
-use image;
-use image_crate;
+use crate::buffer;
+use crate::image;
 use std::{fs, io};
 
 use image_crate::ImageFormat::{JPEG as Jpeg, PNG as Png};
 use std::path::Path;
-use {Document, Error, Gltf, Result};
+use crate::{Document, Error, Gltf, Result};
 
 /// Return type of `import`.
 type Import = (Document, Vec<buffer::Data>, Vec<image::Data>);
@@ -177,7 +176,6 @@ fn import_impl(path: &Path) -> Result<Import> {
 /// Import some glTF 2.0 from the file system.
 ///
 /// ```
-/// # extern crate gltf;
 /// # fn run() -> Result<(), gltf::Error> {
 /// # let path = "examples/Box.gltf";
 /// # #[allow(unused)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,17 +1,16 @@
-use json;
 use std::{iter, slice};
 
-use accessor::Accessor;
-use animation::Animation;
-use buffer::{Buffer, View};
-use camera::Camera;
-use image::Image;
-use material::Material;
-use mesh::Mesh;
-use scene::{Node, Scene};
-use skin::Skin;
-use texture::{Sampler, Texture};
-use ::Document;
+use crate::accessor::Accessor;
+use crate::animation::Animation;
+use crate::buffer::{Buffer, View};
+use crate::camera::Camera;
+use crate::image::Image;
+use crate::material::Material;
+use crate::mesh::Mesh;
+use crate::scene::{Node, Scene};
+use crate::skin::Skin;
+use crate::texture::{Sampler, Texture};
+use crate::Document;
 
 /// An `Iterator` that visits extension strings used by a glTF asset.
 #[derive(Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,6 @@
 #[macro_use]
 extern crate approx;
 #[cfg(feature = "import")]
-extern crate base64;
-extern crate byteorder;
-extern crate cgmath;
-#[cfg(feature = "import")]
 extern crate image as image_crate;
 #[macro_use]
 extern crate lazy_static;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,4 +1,4 @@
-use {json, texture, Document};
+use crate::{texture, Document};
 
 pub use json::material::AlphaMode;
 

--- a/src/mesh/iter.rs
+++ b/src/mesh/iter.rs
@@ -1,8 +1,7 @@
 use std::{collections, iter, slice};
-use json;
 
 use super::{Attribute, Mesh, MorphTarget, Primitive};
-use ::Document;
+use crate::Document;
 
 /// An `Iterator` that visits the morph targets of a `Primitive`.
 #[derive(Clone, Debug)]

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -55,11 +55,10 @@ pub mod iter;
 #[cfg(feature = "utils")]
 pub mod util;
 
-use json;
-use {Accessor, Buffer, Document, Material};
+use crate::{Accessor, Buffer, Document, Material};
 
 #[cfg(feature = "utils")]
-use accessor;
+use crate::accessor;
 
 pub use json::mesh::{Mode, Semantic};
 use json::validation::Checked;

--- a/src/mesh/util/colors.rs
+++ b/src/mesh/util/colors.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
-use Normalize;
+use crate::Normalize;
 
-use mesh::util::ReadColors;
+use super::ReadColors;
 
 /// Casting iterator for `Colors`.
 #[derive(Clone, Debug)]

--- a/src/mesh/util/indices.rs
+++ b/src/mesh/util/indices.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use mesh::util::ReadIndices;
+use super::ReadIndices;
 
 /// Casting iterator for `Indices`.
 #[derive(Clone, Debug)]

--- a/src/mesh/util/joints.rs
+++ b/src/mesh/util/joints.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use mesh::util::ReadJoints;
+use super::ReadJoints;
 
 /// Casting iterator for `Joints`.
 #[derive(Clone, Debug)]

--- a/src/mesh/util/mod.rs
+++ b/src/mesh/util/mod.rs
@@ -13,10 +13,10 @@ pub mod tex_coords;
 /// Casting iterator adapters for node weights.
 pub mod weights;
 
-use mesh;
+use crate::mesh;
 
-use accessor::Iter;
-use Buffer;
+use crate::accessor::Iter;
+use crate::Buffer;
 
 /// XYZ vertex positions of type `[f32; 3]`.
 pub type ReadPositions<'a> = Iter<'a, [f32; 3]>;

--- a/src/mesh/util/tex_coords.rs
+++ b/src/mesh/util/tex_coords.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
-use Normalize;
+use crate::Normalize;
 
-use mesh::util::ReadTexCoords;
+use super::ReadTexCoords;
 
 /// Casting iterator for `TexCoords`.
 #[derive(Clone, Debug)]

--- a/src/mesh/util/weights.rs
+++ b/src/mesh/util/weights.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
-use Normalize;
+use crate::Normalize;
 
-use mesh::util::ReadWeights;
+use super::ReadWeights;
 
 /// Casting iterator for `Weights`.
 #[derive(Clone, Debug)]

--- a/src/scene/iter.rs
+++ b/src/scene/iter.rs
@@ -1,7 +1,6 @@
-use json;
 use std::slice;
 
-use {Document, Node};
+use crate::{Document, Node};
 
 /// An `Iterator` that visits the nodes in a scene.
 #[derive(Clone, Debug)]

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,8 +1,6 @@
-use cgmath;
 use cgmath::prelude::*;
-use json;
 
-use {Camera, Document, Mesh, Skin};
+use crate::{Camera, Document, Mesh, Skin};
 
 /// Iterators.
 pub mod iter;
@@ -240,9 +238,9 @@ impl<'a> Scene<'a> {
 
 #[cfg(test)]
 mod tests {
-    use ::cgmath::{vec3, InnerSpace, Matrix4, Quaternion, Rad, Rotation3};
-    use ::scene::Transform;
-    use ::std::f32::consts::PI;
+    use cgmath::{vec3, InnerSpace, Matrix4, Quaternion, Rad, Rotation3};
+    use crate::scene::Transform;
+    use std::f32::consts::PI;
 
     fn rotate(x: f32, y: f32, z: f32, r: f32) -> [f32; 4] {
         let r = Quaternion::from_axis_angle(vec3(x, y, z).normalize(), Rad(r));

--- a/src/skin/iter.rs
+++ b/src/skin/iter.rs
@@ -1,7 +1,6 @@
-use json;
 use std::slice;
 
-use {Document, Node};
+use crate::{Document, Node};
 
 /// An `Iterator` that visits the joints of a `Skin`.
 #[derive(Clone, Debug)]

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -1,9 +1,7 @@
-use json;
-
-use {Accessor, Document, Node};
+use crate::{Accessor, Document, Node};
 
 #[cfg(feature = "utils")]
-use Buffer;
+use crate::Buffer;
 
 /// Iterators.
 pub mod iter;

--- a/src/skin/util.rs
+++ b/src/skin/util.rs
@@ -1,6 +1,6 @@
-use accessor;
+use crate::accessor;
 
-use {Buffer, Skin};
+use crate::{Buffer, Skin};
 
 /// Inverse Bind Matrices of type `[[f32; 4]; 4]`.
 pub type ReadInverseBindMatrices<'a> = accessor::Iter<'a, [[f32; 4]; 4]>;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,4 +1,4 @@
-use {image, json, Document};
+use crate::{image, Document};
 
 pub use json::texture::{MagFilter, MinFilter, WrappingMode};
 

--- a/tests/import_sanity_check.rs
+++ b/tests/import_sanity_check.rs
@@ -1,5 +1,3 @@
-extern crate gltf;
-
 use std::{fs, path};
 use std::error::Error as StdError;
 

--- a/tests/roundtrip_binary_gltf.rs
+++ b/tests/roundtrip_binary_gltf.rs
@@ -3,8 +3,6 @@
 //! Read some binary glTF, write it to disk, and compare to the original.
 //! The test will succeed if the output is the same as the original.
 
-extern crate gltf;
-
 use std::{boxed, error, fs, io, path};
 use std::io::Read;
 

--- a/tests/test_wrapper.rs
+++ b/tests/test_wrapper.rs
@@ -1,5 +1,3 @@
-extern crate gltf;
-
 use std::{fs, io};
 use std::io::Read;
 


### PR DESCRIPTION
Updates the crate to use the 2018 edition of Rust and fixes all resulting compile errors. This will allow the crate to take advantage of new features such as non-lexical lifetimes in new code.