### PR TITLE
Fix accessor performance

### DIFF
--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -85,9 +85,6 @@ pub struct Accessor<'a> {
 
     /// The corresponding JSON struct.
     json: &'a json::accessor::Accessor,
-
-    /// The buffer view this accessor reads from.
-    view: buffer::View<'a>,
 }
 
 impl<'a> Accessor<'a> {
@@ -97,12 +94,10 @@ impl<'a> Accessor<'a> {
         index: usize,
         json: &'a json::accessor::Accessor,
     ) -> Self {
-        let view = document.views().nth(json.buffer_view.value()).unwrap();
         Self {
             document,
             index,
             json,
-            view,
         }
     }
 


### PR DESCRIPTION
Fixes #207. Fixing the issue turned out to be deceptively simple. It was only a matter of removing the unused `view` field from the `Accessor` struct. Previously, reading in the Sponza Atrium model took up to 5 seconds, but with this PR only takes up around 55 milliseconds on my system.