### PR TITLE
Upgrade Dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,13 @@ base64 = { optional = true, version = "0.6" }
 byteorder = "1.1"
 cgmath = "0.15"
 gltf-json = { path = "gltf-json", version = "0.11.3" }
-image = { optional = true, version = "0.19" }
 lazy_static = "0.2"
+
+[dependencies.image]
+default-features = false
+features = ["jpeg", "png_codec"]
+optional = true
+version = "0.21"
 
 [features]
 default = ["import", "utils", "names"]
@@ -36,6 +41,7 @@ names = ["gltf-json/names"]
 utils = []
 import = ["base64", "image"]
 KHR_materials_pbrSpecularGlossiness = ["gltf-json/KHR_materials_pbrSpecularGlossiness"]
+image_jpeg_rayon = ["image/jpeg_rayon"]
 
 [[example]]
 name = "gltf-display"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ travis-ci = { repository = "gltf-rs/gltf" }
 members = ["gltf-derive", "gltf-json"]
 
 [dev-dependencies]
-approx = "0.1.1"
+approx = "0.3"
 
 [dependencies]
-base64 = { optional = true, version = "0.6" }
+base64 = { optional = true, version = "0.10" }
 byteorder = "1.1"
-cgmath = "0.15"
+cgmath = "0.17"
 gltf-json = { path = "gltf-json", version = "0.11.3" }
-lazy_static = "0.2"
+lazy_static = "1"
 
 [dependencies.image]
 default-features = false

--- a/gltf-derive/Cargo.toml
+++ b/gltf-derive/Cargo.toml
@@ -12,5 +12,6 @@ proc-macro = true
 
 [dependencies]
 inflections = "1.1"
-quote = "0.3"
-syn = "0.11"
+proc-macro2 = "0.4"
+quote = "0.6"
+syn = "0.15"

--- a/src/image.rs
+++ b/src/image.rs
@@ -18,6 +18,12 @@ pub enum Format {
 
     /// Red, green, blue, alpha.
     R8G8B8A8,
+
+    /// Blue, green, red.
+    B8G8R8,
+
+    /// Blue, green, red, alpha.
+    B8G8R8A8,
 }
 
 /// Describes an image data source.
@@ -127,12 +133,14 @@ impl Data {
     /// Note: We don't implement `From<DynamicImage>` since we don't want
     /// to expose such functionality to the user.
     pub(crate) fn new(image: DynamicImage) -> Self {
-        use image_crate::GenericImage;
+        use image_crate::GenericImageView;
         let format = match image {
             DynamicImage::ImageLuma8(_) => Format::R8,
             DynamicImage::ImageLumaA8(_) => Format::R8G8,
             DynamicImage::ImageRgb8(_) => Format::R8G8B8,
             DynamicImage::ImageRgba8(_) => Format::R8G8B8A8,
+            DynamicImage::ImageBgr8(_) => Format::B8G8R8,
+            DynamicImage::ImageBgra8(_) => Format::B8G8R8A8,
         };
         let (width, height) = image.dimensions();
         let pixels = image.raw_pixels();


### PR DESCRIPTION
This PR updates the following outdated dependencies, and fixes the resulting incompatibilities:

- `approx`, 0.1.1 -> 0.3
- `base64`, 0.6 -> 0.10
- `cgmath`, 0.15 -> 0.17
- `image`, 0.19 -> 0.21
- `lazy_static`, 0.2 -> ^1
- `quote`, 0.3 -> 0.6
- `syn`, 0.11 -> 0.15

Updating `quote` requires adding a dependency on `proc_macro2` to `gltf-derive`, but `gltf-json` already transitively requires that anyways.

Updating `image` is slightly complicated by their adding of BGR pixel formats to the `image::DynamicImage` enum. The current PR just adds the new formats to `gltf::image::Format`, though you could, to preserve backwards compatibility, alternatively not add them and report some sort of error when encountered; or, to ensure forwards compatibility, add a hidden __Nonexhaustive variant (see [RFC 2008](https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md) to prevent exhaustive matching.

Additionally, this only asks for `image` features required by the glTF spec (that is, support for PNG and JPEG images), so as to decrease unused code size if someone is not using `image` except through `gltf`. `image`s `jpeg_rayon` parallel JPEG decoding feature is also enabled by default for convenience. Alternatively, of course, we could not do this.