### PR TITLE
Improve documentation

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -33,7 +33,7 @@ pub enum Error {
     UnknownChunkType([u8; 4]),
 }
 
-/// The contents of a .glb file.
+/// Binary glTF contents.
 #[derive(Clone, Debug)]
 pub struct Glb<'a> {
     /// The header section of the `.glb` file.
@@ -256,9 +256,12 @@ impl<'a> Glb<'a> {
         }
     }
 
-    /// Does the loading job for you.  Provided buf will be cleared before new
-    /// data will be written.  When error happens, if only header was read, buf
-    /// will not be mutated, otherwise, buf will be empty.
+    /// Reads binary glTF from a generic stream of data.
+    ///
+    /// # Note
+    ///
+    /// Reading terminates early if the stream does not contain valid binary
+    /// glTF.
     pub fn from_reader<R: io::Read>(mut reader: R) -> Result<Self, crate::Error> {
         let header = Header::from_reader(&mut reader).map_err(crate::Error::Binary)?;
         match header.version {

--- a/src/import.rs
+++ b/src/import.rs
@@ -186,6 +186,20 @@ fn import_impl(path: &Path) -> Result<Import> {
 /// #     run().expect("test failure");
 /// # }
 /// ```
+///
+/// ### Note
+///
+/// This function is provided as a convenience for loading glTF and associated
+/// resources from the file system. It is suitable for real world use but may
+/// not be suitable for all real world use cases. More complex import scenarios
+/// such downloading from web URLs are not handled by this function. These
+/// scenarios are delegated to the user.
+///
+/// You can read glTF without loading resources by constructing the [`Gltf`]
+/// (standard glTF) or [`Glb`] (binary glTF) data structures explicitly.
+///
+/// [`Gltf`]: struct.Gltf.html
+/// [`Glb`]: struct.Glb.html
 pub fn import<P>(path: P) -> Result<Import>
     where P: AsRef<Path>
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@
 //!
 //! # Installation
 //!
-//! Add `gltf` version 0.11 to your `Cargo.toml`.
+//! Add `gltf` version 0.12 to your `Cargo.toml`.
 //!
 //! ```toml
 //! [dependencies.gltf]
-//! version = "0.11"
+//! version = "0.12"
 //! ```
 //!
 //! # Examples
@@ -59,7 +59,20 @@
 //! # }
 //! ```
 //!
+//! ### Note
+//!
+//! This function is provided as a convenience for loading glTF and associated
+//! resources from the file system. It is suitable for real world use but may
+//! not be suitable for all real world use cases. More complex import scenarios
+//! such downloading from web URLs are not handled by this function. These
+//! scenarios are delegated to the user.
+//!
+//! You can read glTF without loading resources by constructing the [`Gltf`]
+//! (standard glTF) or [`Glb`] (binary glTF) data structures explicitly.
+//!
 //! [glTF 2.0]: https://www.khronos.org/gltf
+//! [`Gltf`]: struct.Gltf.html
+//! [`Glb`]: struct.Glb.html
 //! [`Node`]: struct.Node.html
 //! [`Scene`]: struct.Scene.html
 
@@ -118,6 +131,8 @@ pub mod texture;
 pub use self::animation::Animation;
 #[doc(inline)]
 pub use self::accessor::Accessor;
+#[doc(inline)]
+pub use self::binary::Glb;
 #[doc(inline)]
 pub use self::buffer::Buffer;
 #[doc(inline)]


### PR DESCRIPTION
 * Fix incorrect version number in top-level example.
 * Note limitations of the `import` function.
 * Reword documentation for `Glb::from_reader`.