### PR TITLE
Add sRGB color space docs to base_color_texture

### DIFF
--- a/src/material.rs
+++ b/src/material.rs
@@ -191,7 +191,8 @@ impl<'a> PbrMetallicRoughness<'a> {
         self.json.base_color_factor.0
     }
 
-    /// Returns the base color texture.
+    /// Returns the base color texture. The texture contians RGB(A) components
+    /// in sRGB color space.
     pub fn base_color_texture(&self) -> Option<texture::Info<'a>> {
         self.json.base_color_texture.as_ref().map(|json| {
             let texture = self.document.textures().nth(json.index.value()).unwrap();

--- a/src/material.rs
+++ b/src/material.rs
@@ -191,7 +191,7 @@ impl<'a> PbrMetallicRoughness<'a> {
         self.json.base_color_factor.0
     }
 
-    /// Returns the base color texture. The texture contians RGB(A) components
+    /// Returns the base color texture. The texture contains RGB(A) components
     /// in sRGB color space.
     pub fn base_color_texture(&self) -> Option<texture::Info<'a>> {
         self.json.base_color_texture.as_ref().map(|json| {


### PR DESCRIPTION
The emissive and specular_glossiness texture docs explicitly noted that the values are in sRGB color space, but was missing from base_color_texture. 

https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#pbrmetallicroughnessbasecolortexture