### PR TITLE
Add gltf-roundtrip example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Support for the `KHR_lights_punctual` extension.
+- `gltf-roundtrip` example.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,9 @@ name = "gltf-export"
 path = "examples/export/main.rs"
 
 [[example]]
+name = "gltf-roundtrip"
+path = "examples/roundtrip/main.rs"
+
+[[example]]
 name = "gltf-tree"
 path = "examples/tree/main.rs"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Demonstrates how glTF JSON can be built and exported using the `gltf-json` crate
 cargo run --example gltf-export
 ```
 
+#### gltf-roundtrip
+
+Deserializes and serializes the JSON part of a glTF asset.
+
+```sh
+cargo run --example gltf-roundtrip path/to/asset.gltf
+```
+
 #### gltf-tree
 
 Visualises the scene heirarchy of a glTF asset, which is a strict tree of nodes.

--- a/examples/roundtrip/main.rs
+++ b/examples/roundtrip/main.rs
@@ -1,0 +1,21 @@
+use std::{fs, io};
+
+use std::boxed::Box;
+use std::error::Error as StdError;
+
+fn run(path: &str) -> Result<(), Box<StdError>> {
+    let file = fs::File::open(&path)?;
+    let reader = io::BufReader::new(file);
+    let gltf = gltf::Gltf::from_reader(reader)?;
+    let json = gltf.document.into_json().to_string_pretty()?;
+    println!("{}", json);
+    Ok(())
+}
+
+fn main() {
+    if let Some(path) = std::env::args().nth(1) {
+        run(&path).expect("runtime error");
+    } else {
+        println!("usage: gltf-roundtrip <FILE>");
+    }
+}


### PR DESCRIPTION
Writes to `stdout` the JSON portion of a glTF asset as deserialized and serialized by the crate.