### PR TITLE
Update gltf-derive dependencies

### DIFF
--- a/gltf-derive/Cargo.toml
+++ b/gltf-derive/Cargo.toml
@@ -12,6 +12,6 @@ proc-macro = true
 
 [dependencies]
 inflections = "1.1"
-proc-macro2 = "0.4"
-quote = "0.6"
-syn = "0.15"
+proc-macro2 = "1"
+quote = "1"
+syn = "1"


### PR DESCRIPTION
This removes redundantly compiled crates (as imported from serde) speeding up compile times (approximately 2s on my machine).