### PR TITLE
Allow read-only view of Document's JSON root.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,11 @@ impl Document {
         Document(json)
     }
 
+    /// Yields a reference to the contained glTF document.
+    pub fn json(&self) -> &json::Root {
+        &self.0
+    }
+
     /// Unwraps the glTF document.
     pub fn into_json(self) -> json::Root {
         self.0


### PR DESCRIPTION
We're writing a glTF-manipulating tool, where the core operation involves deriving new asset from existing one(s) in various ways. As things stand now, it's awkward to write code that uses the convenient, higher-level `gltf::` methods, while **also** having read access to the underlying `gltf::json::` structures, at least without needless cloning.

Ideally I'd love to have read-only access to the underlying JSON for **every** glTF object, e.g.
```
    gltf::Material::json(&self) -> &gltf::json::Material;
```
but failing that, access at the `Document` level would suffice.

I suspect you have deliberate architectural reasons why you keep the underlying JSON entirely encapsulated, and most of the time I think that's exactly right. The exception I've found, as mentioned above, is when we're building a **new** glTF file, by building up and extending a `gltf::json::Root`. This is obviously done with `gltf::json::` structs, and at that point the ability to clone-and-tweak JSON structs in the original asset is very valuable.

Thoughts?
