### PR TITLE
Revert "separate import from loading data"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,11 @@ optional = true
 version = "0.21"
 
 [features]
-default = ["import", "import_data_reference", "utils", "names"]
+default = ["import", "utils", "names"]
 extras = ["gltf-json/extras"]
 names = ["gltf-json/names"]
 utils = []
-import = []
-import_data_reference = ["base64", "image"]
+import = ["base64", "image"]
 KHR_lights_punctual = ["gltf-json/KHR_lights_punctual"]
 KHR_materials_pbrSpecularGlossiness = ["gltf-json/KHR_materials_pbrSpecularGlossiness"]
 image_jpeg_rayon = ["image/jpeg_rayon"]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,10 +1,10 @@
 use crate::{buffer, Document};
 
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 use image_crate::DynamicImage;
 
 /// Format of image pixel data.
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Format {
     /// Red only.
@@ -62,7 +62,7 @@ pub struct Image<'a> {
 }
 
 /// Image data belonging to an imported glTF asset.
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 #[derive(Clone, Debug)]
 pub struct Data {
     /// The image pixel data (8 bits per channel).
@@ -128,7 +128,7 @@ impl<'a> Image<'a> {
     }
 }
 
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 impl Data {
     /// Note: We don't implement `From<DynamicImage>` since we don't want
     /// to expose such functionality to the user.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 #[cfg(test)]
 #[macro_use]
 extern crate approx;
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 extern crate image as image_crate;
 #[macro_use]
 extern crate lazy_static;
@@ -106,7 +106,7 @@ pub mod camera;
 pub mod image;
 
 /// The reference importer.
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 mod import;
 
 /// Iterators for walking the glTF node hierarchy.
@@ -146,10 +146,10 @@ pub use self::buffer::Buffer;
 pub use self::camera::Camera;
 #[doc(inline)]
 pub use self::image::Image;
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 #[doc(inline)]
 pub use self::import::import;
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 #[doc(inline)]
 pub use self::import::import_slice;
 #[doc(inline)]
@@ -177,7 +177,7 @@ pub type Result<T> = result::Result<T, Error>;
 #[derive(Debug)]
 pub enum Error {
     /// Base 64 decoding error.
-    #[cfg(feature = "import_data_reference")]
+    #[cfg(feature = "import")]
     Base64(base64::DecodeError),
 
     /// GLB parsing error.
@@ -203,7 +203,7 @@ pub enum Error {
     Io(std::io::Error),
 
     /// Image decoding error.
-    #[cfg(feature = "import_data_reference")]
+    #[cfg(feature = "import")]
     Image(image_crate::ImageError),
     
     /// The `BIN` chunk of binary glTF is referenced but does not exist.
@@ -501,7 +501,7 @@ impl Document {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            #[cfg(feature = "import_data_reference")]
+            #[cfg(feature = "import")]
             Error::Base64(ref e) => e.fmt(f),
             Error::Binary(ref e) => e.fmt(f),
             #[cfg(feature = "import")]
@@ -516,7 +516,7 @@ impl std::fmt::Display for Error {
             },
             Error::Deserialize(ref e) => e.fmt(f),
             Error::Io(ref e) => e.fmt(f),
-            #[cfg(feature = "import_data_reference")]
+            #[cfg(feature = "import")]
             Error::Image(ref e) => e.fmt(f),
             #[cfg(feature = "import")]
             Error::MissingBlob => write!(f, "missing binary portion of binary glTF"),
@@ -540,14 +540,14 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            #[cfg(feature = "import_data_reference")]
+            #[cfg(feature = "import")]
             Error::Base64(ref e) => e.description(),
             Error::Binary(ref e) => e.description(),
             #[cfg(feature = "import")]
             Error::BufferLength { .. } => "buffer length does not match expected length",
             Error::Deserialize(ref e) => e.description(),
             Error::Io(ref e) => e.description(),
-            #[cfg(feature = "import_data_reference")]
+            #[cfg(feature = "import")]
             Error::Image(ref e) => e.description(),
             #[cfg(feature = "import")]
             Error::MissingBlob => "missing BIN section of binary glTF",
@@ -574,7 +574,7 @@ impl From<std::io::Error> for Error {
     }
 }
 
-#[cfg(feature = "import_data_reference")]
+#[cfg(feature = "import")]
 impl From<image_crate::ImageError> for Error {
     fn from(err: image_crate::ImageError) -> Self {
         Error::Image(err)


### PR DESCRIPTION
This doesn't achieve anything useful at the moment so I would prefer to leave it out of the next release. The crate doesn't include the `import` function with `--no-default-features --features import` and the crate fails to build with `--no-default-features --features import_data_reference`.

This reverts commit eeac166f66a4a8a0df8ba7b863d4cd9e506112d2.