### PR TITLE
Fix cubic spline docs

### DIFF
--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -50,11 +50,11 @@ pub enum Interpolation {
 
     /// Cubic spline interpolation.
     ///
-    /// The animation's interpolation is computed using a uniform Catmull-Rom spline.
-    /// The number of output elements must equal two more than the number of input
-    /// elements. The first and last output elements represent the start and end
-    /// tangents of the spline. There must be at least four keyframes when using this
-    /// interpolation.
+    /// The animation's interpolation is computed using a cubic spline with specified
+    /// tangents. The number of output elements must equal three times the number of
+    /// input elements. For each input element, the output stores three elements, an
+    /// in-tangent, a spline vertex, and an out-tangent. There must be at least two
+    /// keyframes when using this interpolation
     CubicSpline,
 }
 


### PR DESCRIPTION
I realized the docs here are just copied from the gltf spec, so I made a PR for this myself.

Probably closes https://github.com/gltf-rs/gltf/issues/259

Although I'm still not sure why the catmull rom spline is not in the gltf specs.