### PR TITLE
Fix warnings in examples

### DIFF
--- a/examples/display/main.rs
+++ b/examples/display/main.rs
@@ -3,7 +3,7 @@ use std::{fs, io};
 use std::boxed::Box;
 use std::error::Error as StdError;
 
-fn run(path: &str) -> Result<(), Box<StdError>> {
+fn run(path: &str) -> Result<(), Box<dyn StdError>> {
     let file = fs::File::open(&path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;

--- a/examples/roundtrip/main.rs
+++ b/examples/roundtrip/main.rs
@@ -3,7 +3,7 @@ use std::{fs, io};
 use std::boxed::Box;
 use std::error::Error as StdError;
 
-fn run(path: &str) -> Result<(), Box<StdError>> {
+fn run(path: &str) -> Result<(), Box<dyn StdError>> {
     let file = fs::File::open(&path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;

--- a/examples/tree/main.rs
+++ b/examples/tree/main.rs
@@ -17,7 +17,7 @@ fn print_tree(node: &gltf::Node, depth: i32) {
     }
 }
 
-fn run(path: &str) -> Result<(), Box<StdError>> {
+fn run(path: &str) -> Result<(), Box<dyn StdError>> {
     let file = fs::File::open(&path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;


### PR DESCRIPTION
These warnings were added in a recent rust update.