### PR TITLE
Relax additional lifetimes

### DIFF
--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -130,7 +130,7 @@ impl<'a> Accessor<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 
@@ -151,7 +151,7 @@ impl<'a> Accessor<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 

--- a/src/accessor/sparse.rs
+++ b/src/accessor/sparse.rs
@@ -56,7 +56,7 @@ impl<'a> Indices<'a> {
 
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -100,7 +100,7 @@ impl<'a> Sparse<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -138,7 +138,7 @@ impl<'a> Values<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -78,7 +78,7 @@ impl<'a> Animation<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 
@@ -94,7 +94,7 @@ impl<'a> Animation<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
@@ -151,7 +151,7 @@ impl<'a> Channel<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -174,12 +174,12 @@ impl<'a> Target<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 
     /// Returns the target node.
-    pub fn node(&self) -> scene::Node {
+    pub fn node(&self) -> scene::Node<'a> {
         self.anim.document.nodes().nth(self.json.node.value()).unwrap()
     }
 
@@ -208,7 +208,7 @@ impl<'a> Sampler<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -92,12 +92,12 @@ impl<'a> Buffer<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -154,7 +154,7 @@ impl<'a> View<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
@@ -164,7 +164,7 @@ impl<'a> View<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -61,7 +61,7 @@ impl<'a> Camera<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
@@ -80,7 +80,7 @@ impl<'a> Camera<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -115,7 +115,7 @@ impl<'a> Orthographic<'a> {
     }
 
     ///  Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -150,7 +150,7 @@ impl<'a> Perspective<'a> {
     }
 
     ///  Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -99,7 +99,7 @@ impl<'a> Image<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
@@ -123,7 +123,7 @@ impl<'a> Image<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }

--- a/src/khr_lights_punctual.rs
+++ b/src/khr_lights_punctual.rs
@@ -36,12 +36,12 @@ impl<'a> Light<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &Extras {
+    pub fn extras(&self) -> &'a Extras {
         &self.json.extras
     }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -83,7 +83,7 @@ impl<'a> Material<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 
@@ -171,7 +171,7 @@ impl<'a> Material<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -245,7 +245,7 @@ impl<'a> PbrMetallicRoughness<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -320,7 +320,7 @@ impl<'a> PbrSpecularGlossiness<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -362,7 +362,7 @@ impl<'a> NormalTexture<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }
@@ -404,7 +404,7 @@ impl<'a> OcclusionTexture<'a> {
     }
     
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 }

--- a/src/mesh/iter.rs
+++ b/src/mesh/iter.rs
@@ -20,7 +20,7 @@ pub struct Attributes<'a> {
     pub(crate) document: &'a Document,
 
     /// The parent `Primitive` struct.
-    pub(crate) prim: &'a Primitive<'a>,
+    pub(crate) prim: Primitive<'a>,
 
     /// The internal attribute iterator.
     pub(crate) iter: collections::hash_map::Iter<
@@ -34,7 +34,7 @@ pub struct Attributes<'a> {
 #[derive(Clone, Debug)]
 pub struct Primitives<'a>  {
     /// The parent `Mesh` struct.
-    pub(crate) mesh: &'a Mesh<'a>,
+    pub(crate) mesh: Mesh<'a>,
 
     /// The internal JSON primitive iterator.
     pub(crate) iter: iter::Enumerate<slice::Iter<'a, json::mesh::Primitive>>,
@@ -62,7 +62,7 @@ impl<'a> ExactSizeIterator for Primitives<'a> {}
 impl<'a> Iterator for Primitives<'a> {
     type Item = Primitive<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(index, json)| Primitive::new(self.mesh, index, json))
+        self.iter.next().map(|(index, json)| Primitive::new(self.mesh.clone(), index, json))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -227,13 +227,13 @@ impl<'a> Scene<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras{
+    pub fn extras(&self) -> &'a json::Extras{
         &self.json.extras
     }
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -47,7 +47,7 @@ impl<'a> Skin<'a> {
     }
 
     /// Optional application specific data.
-    pub fn extras(&self) -> &json::Extras {
+    pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
 
@@ -92,7 +92,7 @@ impl<'a> Skin<'a> {
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_ref().map(String::as_str)
     }
 


### PR DESCRIPTION
Followup for #264. Tried to get everything, but good odds I missed a few corners.

Aside all the low hanging fruit, I made a couple more significant changes this time: the `Primitives` iterator and the `Primitive` struct itself now capture `Mesh` by value. This increases their size by two pointers in exchange for avoiding narrowing of lifetimes. An alternative approach would be to add a distrinct lifetime parameter for the `Mesh` references alone, but that would be a breaking change, and is less flexible. Considering how trivial these copies should be for LLVM to optimize, I think the chosen solution is ideal.