### PR TITLE
Implement ExactSizeIterator for accessor::util::Iter

### DIFF
--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -35,6 +35,15 @@ impl<'a, T: Item> Iterator for Iter<'a, T> {
     }
 }
 
+impl<'a, T: Item> ExactSizeIterator for Iter<'a, T> {
+    fn len(&self) -> usize {
+        match self {
+            &Iter::Standard(ref iter) => iter.len(),
+            &Iter::Sparse(ref iter) => iter.values.len(),
+        }
+    }
+}
+
 /// Iterator over indices of sparse accessor.
 #[derive(Clone, Debug)]
 pub enum SparseIndicesIter<'a> {

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -33,16 +33,37 @@ impl<'a, T: Item> Iterator for Iter<'a, T> {
             &mut Iter::Sparse(ref mut iter) => iter.next(),
         }
     }
-}
 
-impl<'a, T: Item> ExactSizeIterator for Iter<'a, T> {
-    fn len(&self) -> usize {
+    fn nth(&mut self, nth: usize) -> Option<Self::Item> {
         match self {
-            &Iter::Standard(ref iter) => iter.len(),
-            &Iter::Sparse(ref iter) => iter.values.len(),
+            &mut Iter::Standard(ref mut iter) => iter.nth(nth),
+            &mut Iter::Sparse(ref mut iter) => iter.nth(nth),
+        }
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        match self {
+            Iter::Standard(iter) => iter.last(),
+            Iter::Sparse(iter) => iter.last(),
+        }
+    }
+
+    fn count(self) -> usize {
+        match self {
+            Iter::Standard(iter) => iter.count(),
+            Iter::Sparse(iter) => iter.count(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            &Iter::Standard(ref iter) => iter.size_hint(),
+            &Iter::Sparse(ref iter) => iter.size_hint(),
         }
     }
 }
+
+impl<'a, T: Item> ExactSizeIterator for Iter<'a, T> {}
 
 /// Iterator over indices of sparse accessor.
 #[derive(Clone, Debug)]
@@ -123,7 +144,14 @@ impl<'a, T: Item> Iterator for SparseIter<'a, T> {
 
         Some(next_value)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let hint = self.values.len() - self.counter as usize;
+        (hint, Some(hint))
+    }
 }
+
+impl<'a, T: Item> ExactSizeIterator for SparseIter<'a, T> {}
 
 /// Represents items that can be read by an [`Accessor`].
 ///


### PR DESCRIPTION
This trait was implemented for `Iter` prior to 0.14. It appears that
the missing trait implementation was an oversight when sparse
accessors were implemented in #246.