### PR TITLE
Try guessing image format when MIME type is missing or invalid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ KHR_lights_punctual = ["gltf-json/KHR_lights_punctual"]
 KHR_materials_pbrSpecularGlossiness = ["gltf-json/KHR_materials_pbrSpecularGlossiness"]
 KHR_materials_unlit = ["gltf-json/KHR_materials_unlit"]
 image_jpeg_rayon = ["image/jpeg_rayon"]
+guess_mime_type = []
 
 [[example]]
 name = "gltf-display"

--- a/src/import.rs
+++ b/src/import.rs
@@ -112,12 +112,17 @@ pub fn import_image_data(
     buffer_data: &[buffer::Data],
 ) -> Result<Vec<image::Data>> {
     let mut images = Vec::new();
+    #[cfg(feature = "guess_mime_type")]
     let guess_format = |encoded_image: &[u8]| {
         match image_crate::guess_format(encoded_image) {
             Ok(image_crate::ImageFormat::PNG) => Some(Png),
             Ok(image_crate::ImageFormat::JPEG) => Some(Jpeg),
             _ => None,
         }
+    };
+    #[cfg(not(feature = "guess_mime_type"))]
+    let guess_format = |_encoded_image: &[u8]| {
+        None
     };
     for image in document.images() {
         match image.source() {

--- a/src/import.rs
+++ b/src/import.rs
@@ -112,18 +112,28 @@ pub fn import_image_data(
     buffer_data: &[buffer::Data],
 ) -> Result<Vec<image::Data>> {
     let mut images = Vec::new();
+    let guess_format = |encoded_image: &[u8]| {
+        match image_crate::guess_format(encoded_image) {
+            Ok(image_crate::ImageFormat::PNG) => Some(Png),
+            Ok(image_crate::ImageFormat::JPEG) => Some(Jpeg),
+            _ => None,
+        }
+    };
     for image in document.images() {
         match image.source() {
             image::Source::Uri { uri, mime_type } if base.is_some() => {
                 match Scheme::parse(uri) {
                     Scheme::Data(Some(annoying_case), base64) => {
-                        let format = match annoying_case.as_ref() {
+                        let encoded_image = base64::decode(&base64).map_err(Error::Base64)?;
+                        let encoded_format = match annoying_case.as_ref() {
                             "image/png" => Png,
                             "image/jpeg" => Jpeg,
-                            _ => return Err(Error::UnsupportedImageEncoding),
+                            _ => match guess_format(&encoded_image) {
+                                Some(format) => format,
+                                None => return Err(Error::UnsupportedImageEncoding),
+                            },
                         };
-                        let encoded_image = base64::decode(&base64).map_err(Error::Base64)?;
-                        let decoded_image = image_crate::load_from_memory_with_format(&encoded_image, format)?;
+                        let decoded_image = image_crate::load_from_memory_with_format(&encoded_image, encoded_format)?;
                         images.push(image::Data::new(decoded_image));
                         continue;
                     },
@@ -134,11 +144,17 @@ pub fn import_image_data(
                 let encoded_format =  match mime_type {
                     Some("image/png") => Png,
                     Some("image/jpeg") => Jpeg,
-                    Some(_) => return Err(Error::UnsupportedImageEncoding),
+                    Some(_) => match guess_format(&encoded_image) {
+                        Some(format) => format,
+                        None => return Err(Error::UnsupportedImageEncoding),
+                    },
                     None => match uri.rsplit(".").next() {
                         Some("png") => Png,
                         Some("jpg") | Some("jpeg") => Jpeg,
-                        _ => return Err(Error::UnsupportedImageEncoding),
+                        _ => match guess_format(&encoded_image) {
+                            Some(format) => format,
+                            None => return Err(Error::UnsupportedImageEncoding),
+                        },
                     },
                 };
                 let decoded_image = image_crate::load_from_memory_with_format(&encoded_image, encoded_format)?;
@@ -152,7 +168,10 @@ pub fn import_image_data(
                 let encoded_format = match mime_type {
                     "image/png" => Png,
                     "image/jpeg" => Jpeg,
-                    _ => return Err(Error::UnsupportedImageEncoding)
+                    _ => match guess_format(encoded_image) {
+                        Some(format) => format,
+                        None => return Err(Error::UnsupportedImageEncoding),
+                    },
                 };
                 let decoded_image = image_crate::load_from_memory_with_format(encoded_image, encoded_format)?;
                 images.push(image::Data::new(decoded_image));


### PR DESCRIPTION
When the MIME type is missing gltf can try guessing the file format by using `image::guess_format`.