### PR TITLE
Prevent an extra allocation and copy per imported file

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -68,7 +68,10 @@ where P: AsRef<Path>
 {
     use io::Read;
     let file = fs::File::open(path.as_ref()).map_err(Error::Io)?;
-    let length = file.metadata().map(|x| x.len()).unwrap_or(0);
+    // Allocate one extra byte so the buffer doesn't need to grow before the
+    // final `read` call at the end of the file.  Don't worry about `usize`
+    // overflow because reading will fail regardless in that case.
+    let length = file.metadata().map(|x| x.len() + 1).unwrap_or(0);
     let mut reader = io::BufReader::new(file);
     let mut data = Vec::with_capacity(length as usize);
     reader.read_to_end(&mut data).map_err(Error::Io)?;


### PR DESCRIPTION
Increase the buffer reservation length by one byte to prevent an extra allocation/copy.

From the `std` lib version of `File::read`:

https://github.com/rust-lang/rust/blob/54b7d21f59a363e53eb1c31d76b40af2ff99321c/src/libstd/fs.rs#L224-L274

```rust
/// Indicates how large a buffer to pre-allocate before reading the entire file.
fn initial_buffer_size(file: &File) -> usize {
    // Allocate one extra byte so the buffer doesn't need to grow before the
    // final `read` call at the end of the file.  Don't worry about `usize`
    // overflow because reading will fail regardless in that case.
    file.metadata().map(|m| m.len() as usize + 1).unwrap_or(0)
}

#[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
    fn inner(path: &Path) -> io::Result<Vec<u8>> {
        let mut file = File::open(path)?;
        let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
        file.read_to_end(&mut bytes)?;
        Ok(bytes)
    }
    inner(path.as_ref())
}
```
