### PR TITLE
Implement `nth` for the primary iterators

### DIFF
--- a/src/animation/iter.rs
+++ b/src/animation/iter.rs
@@ -27,11 +27,37 @@ impl<'a> Iterator for Channels<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|json| Channel::new(self.anim.clone(), json))
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let anim = self.anim;
+        self.iter.last().map(|json| Channel::new(anim, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|json| Channel::new(self.anim.clone(), json))
+    }
 }
 
 impl<'a> Iterator for Samplers<'a> {
     type Item = Sampler<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|json| Sampler::new(self.anim.clone(), json))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let anim = self.anim;
+        self.iter.last().map(|json| Sampler::new(anim, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|json| Sampler::new(self.anim.clone(), json))
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -168,9 +168,18 @@ impl<'a> Iterator for Accessors<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Accessor::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Accessor::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Accessor::new(self.document, index, json))
     }
 }
 
@@ -180,9 +189,18 @@ impl<'a> Iterator for Animations<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Animation::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Animation::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Animation::new(self.document, index, json))
     }
 }
 
@@ -192,9 +210,18 @@ impl<'a> Iterator for Buffers<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Buffer::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Buffer::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Buffer::new(self.document, index, json))
     }
 }
 
@@ -228,9 +255,18 @@ impl<'a> Iterator for Views<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| View::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| View::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| View::new(self.document, index, json))
     }
 }
 
@@ -240,9 +276,18 @@ impl<'a> Iterator for Cameras<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Camera::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Camera::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Camera::new(self.document, index, json))
     }
 }
 
@@ -250,13 +295,20 @@ impl<'a> ExactSizeIterator for Images<'a> {}
 impl<'a> Iterator for Images<'a> {
     type Item = Image<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map(|(index, json)| Image::new(self.document, index, json))
+        self.iter.next().map(|(index, json)| Image::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Image::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Image::new(self.document, index, json))
     }
 }
 
@@ -271,9 +323,18 @@ impl<'a> Iterator for Lights<'a> {
             .next()
             .map(|(index, json)| crate::khr_lights_punctual::Light::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| crate::khr_lights_punctual::Light::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| crate::khr_lights_punctual::Light::new(self.document, index, json))
     }
 }
 
@@ -283,9 +344,18 @@ impl<'a> Iterator for Materials<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Material::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Material::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Material::new(self.document, index, json))
     }
 }
 
@@ -295,9 +365,18 @@ impl<'a> Iterator for Meshes<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Mesh::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Mesh::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Mesh::new(self.document, index, json))
     }
 }
 
@@ -307,9 +386,18 @@ impl<'a> Iterator for Nodes<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Node::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Node::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Node::new(self.document, index, json))
     }
 }
 
@@ -319,9 +407,18 @@ impl<'a> Iterator for Samplers<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Sampler::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Sampler::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Sampler::new(self.document, index, json))
     }
 }
 
@@ -331,9 +428,18 @@ impl<'a> Iterator for Scenes<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Scene::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Scene::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Scene::new(self.document, index, json))
     }
 }
 
@@ -343,9 +449,18 @@ impl<'a> Iterator for Skins<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Skin::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Skin::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Skin::new(self.document, index, json))
     }
 }
 
@@ -355,8 +470,17 @@ impl<'a> Iterator for Textures<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(index, json)| Texture::new(self.document, index, json))
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|(index, json)| Texture::new(document, index, json))
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|(index, json)| Texture::new(self.document, index, json))
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -231,9 +231,17 @@ impl<'a> Iterator for ExtensionsUsed<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(String::as_str)
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+    fn count(self) -> usize {
+        self.0.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        self.0.last().map(String::as_str)
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n).map(String::as_str)
     }
 }
 
@@ -243,9 +251,17 @@ impl<'a> Iterator for ExtensionsRequired<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(String::as_str)
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+    fn count(self) -> usize {
+        self.0.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        self.0.last().map(String::as_str)
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n).map(String::as_str)
     }
 }
 

--- a/src/scene/iter.rs
+++ b/src/scene/iter.rs
@@ -44,8 +44,17 @@ impl<'a> Iterator for Children<'a> {
             .next()
             .map(|index| self.document.nodes().nth(index.value()).unwrap())
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|index| document.nodes().nth(index.value()).unwrap())
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|index| self.document.nodes().nth(index.value()).unwrap())
     }
 }

--- a/src/skin/iter.rs
+++ b/src/skin/iter.rs
@@ -19,4 +19,17 @@ impl<'a> Iterator for Joints<'a>  {
             .next()
             .map(|index| self.document.nodes().nth(index.value()).unwrap())
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+    fn last(self) -> Option<Self::Item> {
+        let document = self.document;
+        self.iter.last().map(|index| document.nodes().nth(index.value()).unwrap())
+    }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n).map(|index| self.document.nodes().nth(index.value()).unwrap())
+    }
 }


### PR DESCRIPTION
The default implementation of `std::iter::Iterator::nth` effectively just calls `next()` for `0..n`. 

```rust
#[stable(feature = "rust1", since = "1.0.0")]
fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
    for x in self {
        if n == 0 {
            return Some(x);
        }
        n -= 1;
    }
    None
}
```

The iterators in this crate are adapters over `std::slice::Iter`, which has a specialized version of `nth` to make it `O(1)`. By implementing `nth` and calling the inner iterator method we can effectively turn `nth` into an indexed array access instead of looping through all of the items. 

https://doc.rust-lang.org/src/core/slice/mod.rs.html#3211-3306
```rust
fn nth(&mut self, n: usize) -> Option<$elem> {
    if n >= len!(self) {
        // This iterator is now empty.
        if mem::size_of::<T>() == 0 {
            // We have to do it this way as `ptr` may never be 0, but `end`
            // could be (due to wrapping).
            self.end = self.ptr.as_ptr();
        } else {
            unsafe {
                // End can't be 0 if T isn't ZST because ptr isn't 0 and end >= ptr
                self.ptr = NonNull::new_unchecked(self.end as *mut T);
            }
        }
        return None;
    }
    // We are in bounds. `post_inc_start` does the right thing even for ZSTs.
    unsafe {
        self.post_inc_start(n as isize);
        Some(next_unchecked!(self))
    }
}
```

https://doc.rust-lang.org/src/core/slice/mod.rs.html#3167
```rust
// Helper function for moving the start of the iterator forwards by `offset` elements,
// returning the old start.
// Unsafe because the offset must not exceed `self.len()`.
#[inline(always)]
unsafe fn post_inc_start(&mut self, offset: isize) -> * $raw_mut T {
    if mem::size_of::<T>() == 0 {
        zst_shrink!(self, offset);
        self.ptr.as_ptr()
    } else {
        let old = self.ptr.as_ptr();
        self.ptr = NonNull::new_unchecked(self.ptr.as_ptr().offset(offset));
        old
    }
}
```

