### PR TITLE
Fix deprecation warnings with `std::error::Error::description`.

### DIFF
--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -139,20 +139,15 @@ impl Validate for std::boxed::Box<serde_json::value::RawValue> {
     }
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::IndexOutOfBounds => "Index out of bounds",
-            Error::Invalid => "Invalid value",
-            Error::Missing => "Missing data",
-        }
-    }
-}
+impl std::error::Error for Error {}
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use std::error::Error;
-        write!(f, "{}", self.description())
+        write!(f, "{}", match *self {
+            Error::IndexOutOfBounds => "Index out of bounds",
+            Error::Invalid => "Invalid value",
+            Error::Missing => "Missing data",
+        })
     }
 }
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -287,27 +287,22 @@ impl<'a> Glb<'a> {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error;
-        write!(f, "{}", self.description())
+        write!(f, "{}", match *self {
+            Error::Io(ref e) => return e.fmt(f),
+            Error::Version(_) => "unsupported version",
+            Error::Magic(_) => "not glTF magic",
+            Error::Length { .. } => "could not completely read the object",
+            Error::ChunkLength { ty, .. } => match ty {
+                ChunkType::Json => "JSON chunk length exceeds that of slice",
+                ChunkType::Bin => "BIN\\0 chunk length exceeds that of slice",
+            },
+            Error::ChunkType(ty) => match ty {
+                ChunkType::Json => "was not expecting JSON chunk",
+                ChunkType::Bin => "was not expecting BIN\\0 chunk",
+            },
+            Error::UnknownChunkType(_) => "unknown chunk type",
+       })
     }
 }
 
-impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-         match *self {
-             Error::Io(ref e) => e.description(),
-             Error::Version(_) => "unsupported version",
-             Error::Magic(_) => "not glTF magic",
-             Error::Length { .. } => "could not completely read the object",
-             Error::ChunkLength { ty, .. } => match ty {
-                 ChunkType::Json => "JSON chunk length exceeds that of slice",
-                 ChunkType::Bin => "BIN\\0 chunk length exceeds that of slice",
-             },
-             Error::ChunkType(ty) => match ty {
-                 ChunkType::Json => "was not expecting JSON chunk",
-                 ChunkType::Bin => "was not expecting BIN\\0 chunk",
-             },
-             Error::UnknownChunkType(_) => "unknown chunk type",
-        }
-    }
-}
+impl ::std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,30 +548,7 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            #[cfg(feature = "import")]
-            Error::Base64(ref e) => e.description(),
-            Error::Binary(ref e) => e.description(),
-            #[cfg(feature = "import")]
-            Error::BufferLength { .. } => "buffer length does not match expected length",
-            Error::Deserialize(ref e) => e.description(),
-            Error::Io(ref e) => e.description(),
-            #[cfg(feature = "import")]
-            Error::Image(ref e) => e.description(),
-            #[cfg(feature = "import")]
-            Error::MissingBlob => "missing BIN section of binary glTF",
-            #[cfg(feature = "import")]
-            Error::ExternalReferenceInSliceImport => "external reference in slice only import",
-            #[cfg(feature = "import")]
-            Error::UnsupportedImageEncoding => "unsupported image encoding",
-            #[cfg(feature = "import")]
-            Error::UnsupportedScheme => "unsupported URI scheme",
-            Error::Validation(_) => "invalid glTF",
-        }
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<binary::Error> for Error {
     fn from(err: binary::Error) -> Self {


### PR DESCRIPTION
Fixes these warnings:
```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
   --> src\lib.rs:560:35
    |
560 |             Error::Io(ref e) => e.description(),
```