### PR TITLE
Update base64 crate v0.11 -> v0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = ["gltf-derive", "gltf-json"]
 approx = "0.3"
 
 [dependencies]
-base64 = { optional = true, version = "0.11" }
+base64 = { optional = true, version = "0.12" }
 byteorder = "1.3"
 gltf-json = { path = "gltf-json", version = "0.15.2" }
 lazy_static = "1"


### PR DESCRIPTION
[Changelog](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md)