### PR TITLE
Make alpha cutoff optional.

### DIFF
--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -22,7 +22,7 @@ pub enum AlphaMode {
     /// the alpha value and the specified alpha cutoff value.
     Mask,
 
-    /// The alpha value is used, to determine the transparence of the rendered output.
+    /// The alpha value is used, to determine the transparency of the rendered output.
     /// The alpha cutoff value is ignored.
     Blend,
 }

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -22,8 +22,8 @@ pub enum AlphaMode {
     /// the alpha value and the specified alpha cutoff value.
     Mask,
 
-    /// The rendered output is either fully opaque or fully transparent depending on
-    /// the alpha value and the specified alpha cutoff value.
+    /// The alpha value is used, to determine the transparence of the rendered output.
+    /// The alpha cutoff value is ignored.
     Blend,
 }
 
@@ -45,7 +45,9 @@ impl ser::Serialize for AlphaMode {
 pub struct Material {
     /// The alpha cutoff value of the material.
     #[serde(rename = "alphaCutoff")]
-    pub alpha_cutoff: AlphaCutoff,
+    //#[cfg_attr(feature = "alphaCutoff", serde(skip_serializing_if = "Option::is_none"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha_cutoff: Option<AlphaCutoff>,
     
     /// The alpha rendering mode of the material.
     ///

--- a/src/material.rs
+++ b/src/material.rs
@@ -51,12 +51,7 @@ impl<'a> Material<'a> {
 
     ///  The optional alpha cutoff value of the material.
     pub fn alpha_cutoff(&self) -> Option<f32> {
-        if self.json.alpha_cutoff.is_some() {
-            return Some(self.json.alpha_cutoff.unwrap().0);
-        }
-        else{
-            None
-        }
+        self.json.alpha_cutoff.map(|value| value.0)
     }
 
     /// The alpha rendering mode of the material.  The material's alpha rendering

--- a/src/material.rs
+++ b/src/material.rs
@@ -49,9 +49,14 @@ impl<'a> Material<'a> {
         self.index
     }
 
-    ///  The alpha cutoff value of the material.
-    pub fn alpha_cutoff(&self) -> f32 {
-        self.json.alpha_cutoff.0
+    ///  The optional alpha cutoff value of the material.
+    pub fn alpha_cutoff(&self) -> Option<f32> {
+        if self.json.alpha_cutoff.is_some() {
+            return Some(self.json.alpha_cutoff.unwrap().0);
+        }
+        else{
+            None
+        }
     }
 
     /// The alpha rendering mode of the material.  The material's alpha rendering


### PR DESCRIPTION
I don't know if this is a welcome change, but I think it should be possible to create _materials_ without an `alphaCutoff` field. 
The reason is that when `"alphaMode" : "BLEND"` is used, this field will be ignored (see this [Issue](https://github.com/KhronosGroup/glTF/issues/1158)).

Therefore the Khronos **glTF-Validator** shows this warning, when the `alphaCutoff` field is present and the `alphaMode` is `BLEND`:
![validation_warning](https://user-images.githubusercontent.com/17967303/109428559-ce4d7d80-79f7-11eb-8551-23176352e2d9.png)

There are also official [examples](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/AlphaBlendModeTest) where this field is ommited for `"alphaMode" : "BLEND"`.

Apart from that I changed the Documentation comment for `"BLEND"` to the following, because it seems it was previously just copied from `"MASK"`:

> The alpha value is used, to determine the transparency of the rendered output.
    The alpha cutoff value is ignored.


