### PR TITLE
Fixed invalid mesh export when 'primitives' is empty.

### DIFF
--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -92,7 +92,6 @@ pub struct Mesh {
     pub name: Option<String>,
 
     /// Defines the geometry to be renderered with a material.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub primitives: Vec<Primitive>,
 
     /// Defines the weights to be applied to the morph targets.


### PR DESCRIPTION
The GLTF standard requires every mesh to contain a `primitives` property. Also, several importers, such as Blender's GLTF import, fail when a mesh does not contain the `primitives` property.

By skipping the serialization of `primitives` property when it is empty, exporting empty meshes will result in an invalid GLTF file. This change removes this attribute so that the `primitives` property is always exported, even when it is empty.

Honestly, this such a minor detail that it's probably not even worth worrying about, as it won't even affect the vast majority of people. The only reason I even noticed this is because I'm writing a modding tool for a game that, for some reason, has empty meshes in certain levels.