### PR TITLE
Fix `Normalize` for `u8`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,11 +614,11 @@ impl Normalize<i16> for u8 {
 }
 
 impl Normalize<u16> for u8 {
-    fn normalize(self) -> u16 { self.max(0) as u16 * 2 }
+    fn normalize(self) -> u16 { self as u16 * 0x100 }
 }
 
 impl Normalize<f32> for u8 {
-    fn normalize(self) -> f32 { (self as f32 * 32767.0_f32.recip()).max(-1.0) }
+    fn normalize(self) -> f32 { self as f32 * 255.0_f32.recip() }
 }
 
 impl Normalize<i8> for i16 {


### PR DESCRIPTION
Hey! This fixes what looks like copy-paste errors in `Normalize` for `u8`

* The `impl Normalize<f32> for u8` was causing `u8` vertex colors to appear black, and now exhibits the correct behavior.
* The `impl Normalize<u16> for u8` I did not test, but it follows the patterns of the other integer `Normalize` implementations.