### PR TITLE
Convert R8G8B8 textures to R8G8B8A8 when importing for better compatibility with GPUs

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -15,9 +15,6 @@ pub enum Format {
     /// Red, green.
     R8G8,
 
-    /// Red, green, blue.
-    R8G8B8,
-
     /// Red, green, blue, alpha.
     R8G8B8A8,
 
@@ -148,12 +145,15 @@ impl<'a> Image<'a> {
 impl Data {
     /// Note: We don't implement `From<DynamicImage>` since we don't want
     /// to expose such functionality to the user.
-    pub(crate) fn new(image: DynamicImage) -> Self {
+    pub(crate) fn new(mut image: DynamicImage) -> Self {
         use image_crate::GenericImageView;
-        let format = match image {
+        let format = match &mut image {
             DynamicImage::ImageLuma8(_) => Format::R8,
             DynamicImage::ImageLumaA8(_) => Format::R8G8,
-            DynamicImage::ImageRgb8(_) => Format::R8G8B8,
+            image @ DynamicImage::ImageRgb8(_) => {
+                *image = DynamicImage::ImageRgba8(image.to_rgba8());
+                Format::R8G8B8A8
+            }
             DynamicImage::ImageRgba8(_) => Format::R8G8B8A8,
             DynamicImage::ImageBgr8(_) => Format::B8G8R8,
             DynamicImage::ImageBgra8(_) => Format::B8G8R8A8,


### PR DESCRIPTION
If you search for `R8G8B8_` on either https://vulkan.gpuinfo.org/listlineartilingformats.php or https://vulkan.gpuinfo.org/listoptimaltilingformats.php you'll see that few GPUs are capable of using them in any meaningful way:

![compatibility](https://user-images.githubusercontent.com/13566135/141700641-7d0d26d5-e8d9-42bc-a533-d58162491b76.png)

No Nvidia or AMD GPUs can sample them, for example: https://vulkan.gpuinfo.org/listdevicescoverage.php?lineartilingformat=R8G8B8_SRGB&featureflagbit=SAMPLED_IMAGE&platform=all.

This is a problem when importing glTF files, as the referenced images often do not have alpha channels. The solution I've come up with here is to remove the `R8G8B8` format and convert `DynamicImage::ImageRgb8`s to RGBA instead.
