### PR TITLE
Migrate tests to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on: pull_request
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Run test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Checkout glTF Sample Models
+        uses: actions/checkout@v2
+        with:
+          name: KhronosGroup/glTF-Sample-Models
+          ref: refs/heads/release
+
+      - name: Tests
+        run: cargo test --all --all-features --release
+      - name: Formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-features


### PR DESCRIPTION
~Also pulls the KhronosGroup/glTF-Sample-Models repository only during tests.~
Just adding the github action for now, removing submodule in another PR
