### PR TITLE
Update dependency on 'image' crate from 0.23 to 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Update dependency on `image` crate from 0.23 to 0.24.
+
 ## [0.16.0] - 2021-05-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ lazy_static = "1"
 default-features = false
 features = ["jpeg", "png"]
 optional = true
-version = "0.23"
+version = "0.24"
 
 [features]
 default = ["import", "utils", "names"]

--- a/src/image.rs
+++ b/src/image.rs
@@ -21,12 +21,6 @@ pub enum Format {
     /// Red, green, blue, alpha.
     R8G8B8A8,
 
-    /// Blue, green, red.
-    B8G8R8,
-
-    /// Blue, green, red, alpha.
-    B8G8R8A8,
-
     /// Red only (16 bits).
     R16,
 
@@ -38,6 +32,12 @@ pub enum Format {
 
     /// Red, green, blue, alpha (16 bits).
     R16G16B16A16,
+
+    /// Red, green, blue (32 bits float)
+    R32G32B32FLOAT,
+
+    /// Red, green, blue, alpha (32 bits float)
+    R32G32B32A32FLOAT,
 }
 
 /// Describes an image data source.
@@ -155,15 +155,16 @@ impl Data {
             DynamicImage::ImageLumaA8(_) => Format::R8G8,
             DynamicImage::ImageRgb8(_) => Format::R8G8B8,
             DynamicImage::ImageRgba8(_) => Format::R8G8B8A8,
-            DynamicImage::ImageBgr8(_) => Format::B8G8R8,
-            DynamicImage::ImageBgra8(_) => Format::B8G8R8A8,
             DynamicImage::ImageLuma16(_) => Format::R16,
             DynamicImage::ImageLumaA16(_) => Format::R16G16,
             DynamicImage::ImageRgb16(_) => Format::R16G16B16,
             DynamicImage::ImageRgba16(_) => Format::R16G16B16A16,
+            DynamicImage::ImageRgb32F(_) => Format::R32G32B32FLOAT,
+            DynamicImage::ImageRgba32F(_) => Format::R32G32B32A32FLOAT,
+            _ => unreachable!("Unmatched DynamicImage format")
         };
         let (width, height) = image.dimensions();
-        let pixels = image.to_bytes();
+        let pixels = image.into_bytes();
         Data { format, width, height, pixels }
     }
 }


### PR DESCRIPTION
When building our repository that depends on `gltf` we found out that it is not using the last `image`. We would appreciate if the dependency could be brought up to date.

Note: I haven't ran rustfmt on the changes as doing so updated 64 files that I had not touched.