### PR TITLE
Fix Primitive::attributes serialization determinism issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix relative file path imports with url encoded characters.
 - Update dependency on `image` crate from 0.23 to 0.24.
+- Fix serialization determinism related to using HashMap for Primitive::attributes. Now uses BTreeMap instead.
 
 ## [1.0.0] - 2022-01-29
 

--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -111,7 +111,7 @@ fn export(output: Output) {
 
     let primitive = json::mesh::Primitive {
         attributes: {
-            let mut map = std::collections::HashMap::new();
+            let mut map = std::collections::BTreeMap::new();
             map.insert(Valid(json::mesh::Semantic::Positions), json::Index::new(0));
             map.insert(Valid(json::mesh::Semantic::Colors(0)), json::Index::new(1));
             map

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -4,7 +4,7 @@ use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::from_value;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt;
 
 /// Corresponds to `GL_POINTS`.
@@ -100,7 +100,7 @@ pub struct Mesh {
 pub struct Primitive {
     /// Maps attribute semantic names to the `Accessor`s containing the
     /// corresponding attribute data.
-    pub attributes: HashMap<Checked<Semantic>, Index<accessor::Accessor>>,
+    pub attributes: BTreeMap<Checked<Semantic>, Index<accessor::Accessor>>,
 
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -205,7 +205,7 @@ pub struct MorphTarget {
 }
 
 /// Vertex attribute semantic name.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum Semantic {
     /// Extra attribute name.
     #[cfg(feature = "extras")]

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -1,5 +1,5 @@
 use serde::{ser, Serialize, Serializer};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::hash::Hash;
 
 use crate::{Path, Root};
@@ -30,7 +30,7 @@ pub enum Error {
 }
 
 /// Specifies a type that has been pre-validated during deserialization or otherwise.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub enum Checked<T> {
     /// The item is valid.
     Valid(T),
@@ -103,7 +103,7 @@ impl<T> Validate for Checked<T> {
     }
 }
 
-impl<K: Eq + Hash + ToString + Validate, V: Validate> Validate for HashMap<K, V> {
+impl<K: ToString + Validate, V: Validate> Validate for BTreeMap<K, V> {
     fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
     where
         P: Fn() -> Path,

--- a/src/mesh/iter.rs
+++ b/src/mesh/iter.rs
@@ -24,7 +24,7 @@ pub struct Attributes<'a> {
     pub(crate) prim: Primitive<'a>,
 
     /// The internal attribute iterator.
-    pub(crate) iter: collections::hash_map::Iter<
+    pub(crate) iter: collections::btree_map::Iter<
         'a,
         json::validation::Checked<json::mesh::Semantic>,
         json::Index<json::accessor::Accessor>,


### PR DESCRIPTION
HashMap uses a hash function that behaves differently based on the moment of the initialization of the program. That leads to the different iteration orders during serialization. Replacing HashMap with BTreeMap fixes the issue