### PR TITLE
Update dependencies: base64 and approx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "gltf-rs/gltf" }
 members = ["gltf-derive", "gltf-json"]
 
 [dev-dependencies]
-approx = "0.3"
+approx = "0.5"
 
 [dependencies]
 base64 = { optional = true, version = "0.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = ["gltf-derive", "gltf-json"]
 approx = "0.3"
 
 [dependencies]
-base64 = { optional = true, version = "0.12" }
+base64 = { optional = true, version = "0.13" }
 byteorder = "1.3"
 gltf-json = { path = "gltf-json", version = "1.0.0" }
 lazy_static = "1"


### PR DESCRIPTION
Latest are always best? :)

(also less likely to cause duplicates for dependent crates)