### PR TITLE
Add more public import facilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub mod image;
 /// The reference importer.
 #[cfg(feature = "import")]
 #[cfg_attr(docsrs, doc(cfg(feature = "import")))]
-mod import;
+pub mod import;
 
 /// Iterators for walking the glTF node hierarchy.
 pub mod iter;


### PR DESCRIPTION
Fixes #222. New public API:

* `gltf::import` module (debatable: it would also be possible to keep this private and re-export the other functions)
* `gltf::import::import` and `gltf::import::import_slice`: These were already available as `gltf::import` and `gltf::import_slice` but now you can also see them at this path
* `gltf::import::{import_buffer_data, import_image_data}`: These already existed but they are now `pub`. This is the part that actually fixes #222.
* `gltf::buffer::Data::{from_source, from_source_and_blob}`: This allows importing just one buffer and getting errors about it. Note that `import::Scheme` is *not* made public here.
* `gltf::image::Data::from_source`: Same thing but for images. Most of the logic from `import_image_data` is now in this function.