### PR TITLE
Fix compilation with `KHR_materials_volume` feature only.

### DIFF
--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -1,16 +1,5 @@
-#[cfg(feature = "KHR_materials_pbrSpecularGlossiness")]
-use crate::material::StrengthFactor;
-#[cfg(any(
-    feature = "KHR_materials_pbrSpecularGlossiness",
-    feature = "KHR_materials_transmission"
-))]
-use crate::texture;
-#[cfg(any(
-    feature = "KHR_materials_pbrSpecularGlossiness",
-    feature = "KHR_materials_transmission",
-    feature = "KHR_materials_ior"
-))]
-use crate::{validation::Validate, Extras};
+#[allow(unused_imports)] // different features use different imports
+use crate::{material::StrengthFactor, texture, validation::Validate, Extras};
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 


### PR DESCRIPTION
`KHR_materials_volume` needs `Validate`, `texture`, and `extras`, but those items were not imported when exactly that feature was enabled.

To fix this and any other similar problems, and prevent reoccurrences, make the `use` unconditional, with `#[allow(unused_imports)]` to avoid warnings when the relevant features are not enabled.