### PR TITLE
Implement `Eq`, `Ord`, and `Hash` for `gltf_json::Index`.

### DIFF
--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -20,7 +20,7 @@ pub trait Get<T> {
 }
 
 /// Represents an offset into an array of type `T` owned by the root glTF object.
-pub struct Index<T>(u32, marker::PhantomData<*const T>);
+pub struct Index<T>(u32, marker::PhantomData<fn() -> T>);
 
 /// The root object of a glTF 2.0 asset.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
@@ -259,9 +259,6 @@ impl<T> PartialEq for Index<T> {
     }
 }
 
-unsafe impl<T> Send for Index<T> {}
-unsafe impl<T> Sync for Index<T> {}
-
 impl<T> std::hash::Hash for Index<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
@@ -341,5 +338,11 @@ mod tests {
     #[test]
     fn index_is_ord() {
         assert!(Index::<Node>::new(1) < Index::new(1234));
+    }
+
+    fn _index_is_send_sync()
+    where
+        Index<Material>: Send + Sync,
+    {
     }
 }

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -241,8 +241,32 @@ impl<T> Clone for Index<T> {
 
 impl<T> Copy for Index<T> {}
 
+impl<T> Ord for Index<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+impl<T> PartialOrd for Index<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Eq for Index<T> {}
+impl<T> PartialEq for Index<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
 unsafe impl<T> Send for Index<T> {}
 unsafe impl<T> Sync for Index<T> {}
+
+impl<T> std::hash::Hash for Index<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
 
 impl<T> fmt::Debug for Index<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -294,3 +318,28 @@ impl_get!(texture::Sampler, samplers);
 impl_get!(Scene, scenes);
 impl_get!(Skin, skins);
 impl_get!(Texture, textures);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn index_is_partialeq() {
+        assert_eq!(Index::<Node>::new(1), Index::new(1));
+        assert_ne!(Index::<Node>::new(1), Index::new(2));
+    }
+
+    #[test]
+    fn index_is_hash() {
+        let set = HashSet::from([Index::<Node>::new(1), Index::new(1234)]);
+        assert!(set.contains(&Index::new(1234)));
+        assert!(!set.contains(&Index::new(999)));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn index_is_ord() {
+        assert!(Index::<Node>::new(1) < Index::new(1234));
+    }
+}


### PR DESCRIPTION
These additional trait implementations will allow `Index`es to be stored in maps and compared with others, which will be useful at least for my purposes in generating glTF and testing the generator.

While I was looking at the code, I also eliminated the `unsafe impl`s by changing the phantom type from `PhantomData<*const T>` to `PhantomData<fn() -> T>`, which avoids the `!Send` that phantom `*const T` causes. This is a separate commit and could be split to a separate PR if desired.