### PR TITLE
Add the `KHR_texture_transform` extension to the `NormalTexture` extensions

### DIFF
--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -125,7 +125,15 @@ pub struct PbrSpecularGlossiness {
 
 /// Defines the normal texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct NormalTexture {}
+pub struct NormalTexture {
+    #[cfg(feature = "KHR_texture_transform")]
+    #[serde(
+        default,
+        rename = "KHR_texture_transform",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub texture_transform: Option<super::texture::TextureTransform>,
+}
 
 /// Defines the occlusion texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -193,7 +193,7 @@ pub struct NormalTexture {
 
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub extensions: Option<extensions::material::NormalTexture>,
+    pub extensions: Option<extensions::texture::Info>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -193,7 +193,7 @@ pub struct NormalTexture {
 
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub extensions: Option<extensions::texture::Info>,
+    pub extensions: Option<extensions::material::NormalTexture>,
 
     /// Optional application specific data.
     #[serde(default)]

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,4 +1,7 @@
-use crate::{texture, Document};
+use crate::{
+    texture::{self, TextureTransform},
+    Document,
+};
 
 pub use json::material::AlphaMode;
 
@@ -562,6 +565,18 @@ impl<'a> NormalTexture<'a> {
     /// Returns the referenced texture.
     pub fn texture(&self) -> texture::Texture<'a> {
         self.texture.clone()
+    }
+
+    /// Returns texture transform information
+    #[cfg(feature = "KHR_texture_transform")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "KHR_texture_transform")))]
+    pub fn texture_transform(&self) -> Option<TextureTransform<'a>> {
+        self.json
+            .extensions
+            .as_ref()?
+            .texture_transform
+            .as_ref()
+            .map(TextureTransform::new)
     }
 
     /// Optional application specific data.


### PR DESCRIPTION
The SheenCloth model, for example, uses a texture transform: https://github.com/KhronosGroup/glTF-Sample-Models/blob/16e803435fca5b07dde3dbdc5bd0e9b8374b2750/2.0/SheenCloth/glTF/SheenCloth.gltf#L152-L162.