### PR TITLE
Fix bounds calculation in export example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix relative file path imports with url encoded characters.
 - Update dependency on `image` crate from 0.23 to 0.24.
+- Fix bounds calculation in export example.
 
 ## [1.0.0] - 2022-01-29
 

--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -24,8 +24,8 @@ struct Vertex {
 
 /// Calculate bounding coordinates of a list of vertices, used for the clipping distance of the model
 fn bounding_coords(points: &[Vertex]) -> ([f32; 3], [f32; 3]) {
-    let mut min = [0., 0., 0.];
-    let mut max = [0., 0., 0.];
+    let mut min = [f32::MAX, f32::MAX, f32::MAX];
+    let mut max = [f32::MIN, f32::MIN, f32::MIN];
 
     for point in points {
         let p = point.position;


### PR DESCRIPTION
This fixes the bounds calculation in the export example.