### PR TITLE
Add transmission ext. support to list of extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following glTF extensions are supported by the crate:
 * `KHR_materials_variants`
 * `KHR_materials_volume`
 * `KHR_materials_specular`
+* `KHR_materials_transmission`
 
 To use an extension, list its name in the `features` section.
 


### PR DESCRIPTION
Saw that there was a missing supported extension in the README.md list :) 