### PR TITLE
Make `urlencoding` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ base64 = { optional = true, version = "0.13" }
 byteorder = "1.3"
 gltf-json = { path = "gltf-json", version = "1.1.0" }
 lazy_static = "1"
-urlencoding = "2.1"
+urlencoding = { optional = true, version = "2.1" }
 
 [dependencies.image]
 default-features = false
@@ -39,7 +39,7 @@ default = ["import", "utils", "names"]
 extras = ["gltf-json/extras"]
 names = ["gltf-json/names"]
 utils = []
-import = ["base64", "image"]
+import = ["base64", "image", "urlencoding"]
 KHR_lights_punctual = ["gltf-json/KHR_lights_punctual"]
 KHR_materials_pbrSpecularGlossiness = ["gltf-json/KHR_materials_pbrSpecularGlossiness"]
 KHR_materials_unlit = ["gltf-json/KHR_materials_unlit"]


### PR DESCRIPTION
This dependency is actually only used with feature `import`