### PR TITLE
Syn2, bump msrv to match `image`, and `edition = "2021"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ readme = "README.md"
 keywords = ["glTF", "3D", "asset", "model", "scene"]
 license = "MIT OR Apache-2.0"
 include = ["**/*.rs", "Cargo.toml", "LICENSE-*"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.61"
 
 [badges]
 travis-ci = { repository = "gltf-rs/gltf" }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 This crate is intended to load [glTF 2.0](https://www.khronos.org/gltf), a file format designed for the efficient transmission of 3D assets.
 
-`rustc` version 1.32 or above is required.
+`rustc` version 1.61 or above is required.
 
 ### Reference infographic
 

--- a/examples/display/main.rs
+++ b/examples/display/main.rs
@@ -4,7 +4,7 @@ use std::boxed::Box;
 use std::error::Error as StdError;
 
 fn run(path: &str) -> Result<(), Box<dyn StdError>> {
-    let file = fs::File::open(&path)?;
+    let file = fs::File::open(path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;
     println!("{:#?}", gltf);

--- a/examples/roundtrip/main.rs
+++ b/examples/roundtrip/main.rs
@@ -4,7 +4,7 @@ use std::boxed::Box;
 use std::error::Error as StdError;
 
 fn run(path: &str) -> Result<(), Box<dyn StdError>> {
-    let file = fs::File::open(&path)?;
+    let file = fs::File::open(path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;
     let json = gltf.document.into_json().to_string_pretty()?;

--- a/examples/tree/main.rs
+++ b/examples/tree/main.rs
@@ -18,7 +18,7 @@ fn print_tree(node: &gltf::Node, depth: i32) {
 }
 
 fn run(path: &str) -> Result<(), Box<dyn StdError>> {
-    let file = fs::File::open(&path)?;
+    let file = fs::File::open(path)?;
     let reader = io::BufReader::new(file);
     let gltf = gltf::Gltf::from_reader(reader)?;
     for scene in gltf.scenes() {

--- a/gltf-derive/Cargo.toml
+++ b/gltf-derive/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["David Harvey-Macaulay <alteous@outlook.com>"]
 description = "Internal macros for the gltf crate"
 repository = "https://github.com/gltf-rs/gltf"
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/gltf-derive/Cargo.toml
+++ b/gltf-derive/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 inflections = "1.1"
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = "2"

--- a/gltf-derive/src/lib.rs
+++ b/gltf-derive/src/lib.rs
@@ -50,7 +50,7 @@ fn expand(ast: &DeriveInput) -> proc_macro2::TokenStream {
                 _report: &mut R
             ) where
                 P: Fn() -> crate::Path,
-                R: FnMut(&Fn() -> crate::Path, crate::validation::Error),
+                R: FnMut(&dyn Fn() -> crate::Path, crate::validation::Error),
             {
                 #(
                     #validations;

--- a/gltf-json/Cargo.toml
+++ b/gltf-json/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["David Harvey-Macaulay <alteous@outlook.com>"]
 description = "JSON parsing for the gltf crate"
 repository = "https://github.com/gltf-rs/gltf"
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
+rust-version = "1.61"
 
 [dependencies]
 gltf-derive = { path = "../gltf-derive", version = "1.1.0" }

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -158,7 +158,7 @@ impl Validate for Animation {
         self.samplers
             .validate(root, || path().field("samplers"), report);
         for (index, channel) in self.channels.iter().enumerate() {
-            if channel.sampler.value() as usize >= self.samplers.len() {
+            if channel.sampler.value() >= self.samplers.len() {
                 let path = || path().field("channels").index(index).field("sampler");
                 report(&path, Error::IndexOutOfBounds);
             }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,3 +1,4 @@
+#[allow(unused)]
 use crate::{buffer, Document, Error, Result};
 
 #[cfg(feature = "import")]

--- a/src/import.rs
+++ b/src/import.rs
@@ -55,7 +55,7 @@ impl<'a> Scheme<'a> {
         match Scheme::parse(uri) {
             // The path may be unused in the Scheme::Data case
             // Example: "uri" : "data:application/octet-stream;base64,wsVHPgA...."
-            Scheme::Data(_, base64) => base64::decode(&base64).map_err(Error::Base64),
+            Scheme::Data(_, base64) => base64::decode(base64).map_err(Error::Base64),
             Scheme::File(path) if base.is_some() => read_to_end(path),
             Scheme::Relative(path) if base.is_some() => read_to_end(base.unwrap().join(&*path)),
             Scheme::Unsupported => Err(Error::UnsupportedScheme),
@@ -126,7 +126,7 @@ pub fn import_image_data(
         let decoded_image = match image.source() {
             image::Source::Uri { uri, mime_type } if base.is_some() => match Scheme::parse(uri) {
                 Scheme::Data(Some(annoying_case), base64) => {
-                    let encoded_image = base64::decode(&base64).map_err(Error::Base64)?;
+                    let encoded_image = base64::decode(base64).map_err(Error::Base64)?;
                     let encoded_format = match annoying_case {
                         "image/png" => Png,
                         "image/jpeg" => Jpeg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,7 @@ impl Gltf {
         R: io::Read + io::Seek,
     {
         let gltf = Self::from_reader_without_validation(reader)?;
-        let _ = gltf.document.validate()?;
+        gltf.document.validate()?;
         Ok(gltf)
     }
 
@@ -323,7 +323,7 @@ impl Gltf {
     /// Loads glTF from a slice of bytes.
     pub fn from_slice(slice: &[u8]) -> Result<Self> {
         let gltf = Self::from_slice_without_validation(slice)?;
-        let _ = gltf.document.validate()?;
+        gltf.document.validate()?;
         Ok(gltf)
     }
 }
@@ -345,7 +345,7 @@ impl Document {
     /// Loads glTF from pre-deserialized JSON.
     pub fn from_json(json: json::Root) -> Result<Self> {
         let document = Self::from_json_without_validation(json);
-        let _ = document.validate()?;
+        document.validate()?;
         Ok(document)
     }
 
@@ -579,7 +579,7 @@ impl std::fmt::Display for Error {
             Error::UnsupportedScheme => write!(f, "unsupported URI scheme"),
             Error::Validation(ref xs) => {
                 write!(f, "invalid glTF:")?;
-                for &(ref path, ref error) in xs {
+                for (ref path, ref error) in xs {
                     write!(f, " {}: {};", path, error)?;
                 }
                 Ok(())

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -125,7 +125,9 @@ pub struct Reader<'a, 's, F>
 where
     F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
 {
+    #[allow(dead_code)]
     pub(crate) primitive: &'a Primitive<'a>,
+    #[allow(dead_code)]
     pub(crate) get_buffer_data: F,
 }
 

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -256,7 +256,7 @@ impl<'a> Primitive<'a> {
         } else {
             iter::MorphTargets {
                 document: self.mesh.document,
-                iter: (&[]).iter(),
+                iter: ([]).iter(),
             }
         }
     }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -190,9 +190,9 @@ impl<'a> Node<'a> {
             }
         } else {
             Transform::Decomposed {
-                translation: self.json.translation.unwrap_or_else(|| [0.0, 0.0, 0.0]),
+                translation: self.json.translation.unwrap_or([0.0, 0.0, 0.0]),
                 rotation: self.json.rotation.unwrap_or_default().0,
-                scale: self.json.scale.unwrap_or_else(|| [1.0, 1.0, 1.0]),
+                scale: self.json.scale.unwrap_or([1.0, 1.0, 1.0]),
             }
         }
     }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -138,7 +138,7 @@ impl<'a> Texture<'a> {
             .map(|index| {
                 self.document
                     .samplers()
-                    .nth(index.value() as usize)
+                    .nth(index.value())
                     .unwrap()
             })
             .unwrap_or_else(|| Sampler::default(self.document))
@@ -148,7 +148,7 @@ impl<'a> Texture<'a> {
     pub fn source(&self) -> image::Image<'a> {
         self.document
             .images()
-            .nth(self.json.source.value() as usize)
+            .nth(self.json.source.value())
             .unwrap()
     }
 

--- a/tests/import_sanity_check.rs
+++ b/tests/import_sanity_check.rs
@@ -21,7 +21,7 @@ fn sanity_check(
 
 fn run() -> Result<(), Box<dyn StdError>> {
     let sample_dir_path = path::Path::new(SAMPLE_MODELS_DIRECTORY_PATH);
-    for entry in fs::read_dir(&sample_dir_path)? {
+    for entry in fs::read_dir(sample_dir_path)? {
         let entry = entry?;
         let metadata = entry.metadata()?;
         if metadata.is_dir() {
@@ -67,13 +67,13 @@ fn run() -> Result<(), Box<dyn StdError>> {
 fn sparse_accessor_without_buffer_view_test() -> Result<(), Box<dyn StdError>> {
     let glb_path = path::Path::new("tests/box_sparse.glb");
     print!("{:?}: ", glb_path);
-    let result = gltf::import(&glb_path)?;
+    let result = gltf::import(glb_path)?;
     sanity_check(&result.0, &result.1, &result.2);
     println!("ok");
 
     let gltf_path = path::Path::new("tests/box_sparse.gltf");
     print!("{:?}: ", gltf_path);
-    let result = gltf::import(&gltf_path)?;
+    let result = gltf::import(gltf_path)?;
     sanity_check(&result.0, &result.1, &result.2);
     println!("ok");
     Ok(())


### PR DESCRIPTION
`gltf-derive` still seems to work with the syn2 bump, the only change I had to do was fix it so it'd compile with `edition = 2021`.

The msrv in the readme was wrong, so I bumped it up to match `image`'s current msrv and added rust-version fields to `cargo.toml`.

There were a bunch of clippy errors so I fixed them.