### PR TITLE
Make byte_offset optional for sparse accessors

### DIFF
--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -95,7 +95,7 @@ fn export(output: Output) {
     };
     let positions = json::Accessor {
         buffer_view: Some(json::Index::new(0)),
-        byte_offset: 0,
+        byte_offset: Some(0),
         count: triangle_vertices.len() as u32,
         component_type: Valid(json::accessor::GenericComponentType(
             json::accessor::ComponentType::F32,
@@ -111,7 +111,7 @@ fn export(output: Output) {
     };
     let colors = json::Accessor {
         buffer_view: Some(json::Index::new(0)),
-        byte_offset: (3 * mem::size_of::<f32>()) as u32,
+        byte_offset: Some((3 * mem::size_of::<f32>()) as u32),
         count: triangle_vertices.len() as u32,
         component_type: Valid(json::accessor::GenericComponentType(
             json::accessor::ComponentType::F32,

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -179,8 +179,11 @@ pub struct Accessor {
     pub buffer_view: Option<Index<buffer::View>>,
 
     /// The offset relative to the start of the parent `BufferView` in bytes.
+    ///
+    /// This field can be omitted in sparse accessors.
     #[serde(default, rename = "byteOffset")]
-    pub byte_offset: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_offset: Option<u32>,
 
     /// The number of components within the buffer view - not to be confused
     /// with the number of bytes in the buffer view.

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -120,9 +120,11 @@ impl<'a> Accessor<'a> {
 
     /// Returns the offset relative to the start of the parent buffer view in bytes.
     ///
-    /// This may be `None` if the corresponding accessor is sparse.
-    pub fn offset(&self) -> Option<usize> {
-        self.json.byte_offset.map(|offset| offset as usize)
+    /// This will be 0 if the corresponding accessor is sparse.
+    pub fn offset(&self) -> usize {
+        // TODO: Change this function to return Option<usize> in the next
+        // version and return None for sparse accessors.
+        self.json.byte_offset.unwrap_or(0) as usize
     }
 
     /// Returns the number of components within the buffer view - not to be confused

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -7,7 +7,7 @@
 //! # let gltf = gltf::Gltf::open("examples/Box.gltf")?;
 //! for accessor in gltf.accessors() {
 //!     println!("Accessor #{}", accessor.index());
-//!     println!("offset: {}", accessor.offset());
+//!     println!("offset: {:?}", accessor.offset());
 //!     println!("count: {}", accessor.count());
 //!     println!("data_type: {:?}", accessor.data_type());
 //!     println!("dimensions: {:?}", accessor.dimensions());
@@ -119,8 +119,10 @@ impl<'a> Accessor<'a> {
     }
 
     /// Returns the offset relative to the start of the parent buffer view in bytes.
-    pub fn offset(&self) -> usize {
-        self.json.byte_offset as usize
+    ///
+    /// This may be `None` if the corresponding accessor is sparse.
+    pub fn offset(&self) -> Option<usize> {
+        self.json.byte_offset.map(|offset| offset as usize)
     }
 
     /// Returns the number of components within the buffer view - not to be confused

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -288,10 +288,10 @@ impl<'a, 's, T: Item> Iter<'s, T> {
         match accessor.sparse() {
             Some(sparse) => {
                 // Using `if let` here instead of map to preserve the early return behavior.
-                let base_iter = if let Some(view) = accessor.view() {
+                let base_iter = if let Some((view, start)) = accessor.view().zip(accessor.offset())
+                {
                     let stride = view.stride().unwrap_or(mem::size_of::<T>());
 
-                    let start = accessor.offset();
                     let end = start + stride * (accessor.count() - 1) + mem::size_of::<T>();
                     let subslice = buffer_view_slice(view, &get_buffer_data)
                         .and_then(|slice| slice.get(start..end))?;
@@ -348,26 +348,28 @@ impl<'a, 's, T: Item> Iter<'s, T> {
                 debug_assert_eq!(mem::size_of::<T>(), accessor.size());
                 debug_assert!(mem::size_of::<T>() > 0);
 
-                accessor.view().and_then(|view| {
-                    let stride = view.stride().unwrap_or(mem::size_of::<T>());
-                    debug_assert!(
-                        stride >= mem::size_of::<T>(),
-                        "Mismatch in stride, expected at least {} stride but found {}",
-                        mem::size_of::<T>(),
-                        stride
-                    );
+                accessor
+                    .view()
+                    .zip(accessor.offset())
+                    .and_then(|(view, start)| {
+                        let stride = view.stride().unwrap_or(mem::size_of::<T>());
+                        debug_assert!(
+                            stride >= mem::size_of::<T>(),
+                            "Mismatch in stride, expected at least {} stride but found {}",
+                            mem::size_of::<T>(),
+                            stride
+                        );
 
-                    let start = accessor.offset();
-                    let end = start + stride * (accessor.count() - 1) + mem::size_of::<T>();
-                    let subslice = buffer_view_slice(view, &get_buffer_data)
-                        .and_then(|slice| slice.get(start..end))?;
+                        let end = start + stride * (accessor.count() - 1) + mem::size_of::<T>();
+                        let subslice = buffer_view_slice(view, &get_buffer_data)
+                            .and_then(|slice| slice.get(start..end))?;
 
-                    Some(Iter::Standard(ItemIter {
-                        stride,
-                        data: subslice,
-                        _phantom: PhantomData,
-                    }))
-                })
+                        Some(Iter::Standard(ItemIter {
+                            stride,
+                            data: subslice,
+                            _phantom: PhantomData,
+                        }))
+                    })
             }
         }
     }


### PR DESCRIPTION
This fixes validation of sparse accessors without buffer_views, which must not have a byte_offset. This is not explicit in the spec but is in the official validator (see https://github.com/KhronosGroup/glTF-Validator/issues/207)