### PR TITLE
Remove the dependency on lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ approx = "0.5"
 base64 = { optional = true, version = "0.13" }
 byteorder = "1.3"
 gltf-json = { path = "gltf-json", version = "1.0.0" }
-lazy_static = "1"
 urlencoding = "2.1"
 
 [dependencies.image]

--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -17,7 +17,7 @@ pub type Extras = Void;
 #[derive(Clone, Default, Serialize, Deserialize, Validate)]
 pub struct Void {
     #[serde(default, skip_serializing)]
-    _allow_unknown_fields: (),
+    pub(crate) _allow_unknown_fields: (),
 }
 
 impl fmt::Debug for Void {

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -1,5 +1,5 @@
 use crate::validation::{Checked, Validate};
-use crate::{extensions, texture, Extras, Index};
+use crate::{extensions, texture, Extras, Index, extras::Void};
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
@@ -126,6 +126,41 @@ pub struct Material {
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     #[cfg_attr(not(feature = "extras"), serde(skip_serializing))]
     pub extras: Extras,
+}
+
+impl Material {
+    // A const version of the material returned when calling [`Material::default`] 
+    pub const DEFAULT_MATERIAL: Material = Material {
+        alpha_cutoff: None,
+        alpha_mode: Checked::Valid(AlphaMode::Opaque),
+        double_sided: false,
+        name: None,
+        pbr_metallic_roughness: PbrMetallicRoughness {
+            base_color_factor: PbrBaseColorFactor([0.0, 0.0, 0.0, 0.0]),
+            base_color_texture: None,
+            metallic_factor: StrengthFactor(0.0),
+            roughness_factor: StrengthFactor(0.0),
+            metallic_roughness_texture: None,
+            extensions: None,
+            #[cfg(feature = "extras")]
+            extras: None,
+            #[cfg(not(feature = "extras"))]
+            extras: Void {
+                _allow_unknown_fields: ()
+            }
+        },
+        normal_texture: None,
+        occlusion_texture: None,
+        emissive_texture: None,
+        emissive_factor: EmissiveFactor([0.0, 0.0, 0.0]),
+        extensions: None,
+        #[cfg(feature = "extras")]
+        extras: None,
+        #[cfg(not(feature = "extras"))]
+        extras: Void {
+            _allow_unknown_fields: ()
+        }
+    };
 }
 
 /// A set of parameter values that are used to define the metallic-roughness

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -1,5 +1,5 @@
 use crate::validation::Checked;
-use crate::{extensions, image, Extras, Index};
+use crate::{extensions, image, Extras, Index, extras::Void};
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
@@ -164,6 +164,24 @@ pub struct Sampler {
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     #[cfg_attr(not(feature = "extras"), serde(skip_serializing))]
     pub extras: Extras,
+}
+
+impl Sampler {
+    // A const version of the material returned when calling [`Sampler::default`] 
+    pub const DEFAULT_SAMPLER: Sampler = Sampler {
+        mag_filter: None,
+        min_filter: None,
+        name: None,
+        wrap_s: Checked::Valid(WrappingMode::Repeat),
+        wrap_t: Checked::Valid(WrappingMode::Repeat),
+        extensions: None,
+        #[cfg(feature = "extras")]
+        extras: None,
+        #[cfg(not(feature = "extras"))]
+        extras: Void {
+            _allow_unknown_fields: ()
+        }
+    };
 }
 
 /// A texture and its sampler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,6 @@
 extern crate approx;
 #[cfg(feature = "import")]
 extern crate image as image_crate;
-#[macro_use]
-extern crate lazy_static;
 
 /// Contains (de)serializable data structures that match the glTF JSON text.
 pub extern crate gltf_json as json;

--- a/src/material.rs
+++ b/src/material.rs
@@ -2,10 +2,6 @@ use crate::{texture, Document};
 
 pub use json::material::AlphaMode;
 
-lazy_static! {
-    static ref DEFAULT_MATERIAL: json::material::Material = Default::default();
-}
-
 /// The material appearance of a primitive.
 #[derive(Clone, Debug)]
 pub struct Material<'a> {
@@ -38,7 +34,7 @@ impl<'a> Material<'a> {
         Self {
             document,
             index: None,
-            json: &DEFAULT_MATERIAL,
+            json: &json::material::Material::DEFAULT_MATERIAL,
         }
     }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -2,10 +2,6 @@ use crate::{image, Document};
 
 pub use json::texture::{MagFilter, MinFilter, WrappingMode};
 
-lazy_static! {
-    static ref DEFAULT_SAMPLER: json::texture::Sampler = Default::default();
-}
-
 /// A reference to a `Texture`.
 #[derive(Clone, Debug)]
 pub struct Info<'a> {
@@ -62,7 +58,7 @@ impl<'a> Sampler<'a> {
         Self {
             document,
             index: None,
-            json: &DEFAULT_SAMPLER,
+            json: &json::texture::Sampler::DEFAULT_SAMPLER,
         }
     }
 


### PR DESCRIPTION
This is one of the last instances of `lazy_static` in Bevy's dependency tree. This PR removes it and replaces its uses with the use of consts instead.