### PR TITLE
`KHR_texture_transform` for NormalTexture/OcclusionTexture

### DIFF
--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -3,6 +3,9 @@ use crate::{material::StrengthFactor, texture, validation::Validate, Extras};
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 
+#[cfg(feature = "KHR_texture_transform")]
+use super::texture::TextureTransform;
+
 /// The material appearance of a primitive.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Material {
@@ -122,11 +125,27 @@ pub struct PbrSpecularGlossiness {
 
 /// Defines the normal texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct NormalTexture {}
+pub struct NormalTexture {
+    #[cfg(feature = "KHR_texture_transform")]
+    #[serde(
+        default,
+        rename = "KHR_texture_transform",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub texture_transform: Option<TextureTransform>,
+}
 
 /// Defines the occlusion texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct OcclusionTexture {}
+pub struct OcclusionTexture {
+    #[cfg(feature = "KHR_texture_transform")]
+    #[serde(
+        default,
+        rename = "KHR_texture_transform",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub texture_transform: Option<TextureTransform>,
+}
 
 /// The diffuse factor of a material.
 #[cfg(feature = "KHR_materials_pbrSpecularGlossiness")]

--- a/src/material.rs
+++ b/src/material.rs
@@ -2,6 +2,9 @@ use crate::{texture, Document};
 
 pub use json::material::AlphaMode;
 
+#[cfg(feature = "KHR_texture_transform")]
+use crate::texture::TextureTransform;
+
 lazy_static! {
     static ref DEFAULT_MATERIAL: json::material::Material = Default::default();
 }
@@ -580,6 +583,18 @@ impl<'a> NormalTexture<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Returns texture transform information
+    #[cfg(feature = "KHR_texture_transform")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "KHR_texture_transform")))]
+    pub fn texture_transform(&self) -> Option<TextureTransform<'a>> {
+        self.json
+            .extensions
+            .as_ref()?
+            .texture_transform
+            .as_ref()
+            .map(TextureTransform::new)
+    }
 }
 
 /// Defines the occlusion texture of a material.
@@ -618,6 +633,18 @@ impl<'a> OcclusionTexture<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Returns texture transform information
+    #[cfg(feature = "KHR_texture_transform")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "KHR_texture_transform")))]
+    pub fn texture_transform(&self) -> Option<TextureTransform<'a>> {
+        self.json
+            .extensions
+            .as_ref()?
+            .texture_transform
+            .as_ref()
+            .map(TextureTransform::new)
     }
 }
 


### PR DESCRIPTION
This fixes the abscence of .texture_transform() field for NormalTexture and OcclusionTexture structs with KHR_texture_transform enabled.
This is a dumb copypasta, I might still need to write some tests and move TextureTransform to a separate file.