### PR TITLE
Arbitrary Extension API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ byteorder = "1.3"
 gltf-json = { path = "gltf-json", version = "1.3.0" }
 lazy_static = "1"
 urlencoding = { optional = true, version = "2.1" }
+serde_json = { features = ["raw_value"], version = "1.0" }
 
 [dependencies.image]
 default-features = false
@@ -37,6 +38,7 @@ version = "0.24"
 
 [features]
 default = ["import", "utils", "names"]
+extensions = ["gltf-json/extensions"]
 extras = ["gltf-json/extras"]
 names = ["gltf-json/names"]
 utils = []

--- a/gltf-json/Cargo.toml
+++ b/gltf-json/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { features = ["raw_value"], version = "1.0" }
 [features]
 default = []
 names = []
+extensions = []
 extras = []
 KHR_lights_punctual = []
 KHR_materials_ior = []

--- a/gltf-json/src/extensions/accessor.rs
+++ b/gltf-json/src/extensions/accessor.rs
@@ -1,5 +1,7 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Contains data structures for sparse storage.
 pub mod sparse {
@@ -21,4 +23,8 @@ pub mod sparse {
 
 /// A typed view into a buffer view.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Accessor {}
+pub struct Accessor {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/animation.rs
+++ b/gltf-json/src/extensions/animation.rs
@@ -1,9 +1,15 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// A keyframe animation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Animation {}
+pub struct Animation {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// Targets an animation's sampler at a node's property.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/gltf-json/src/extensions/buffer.rs
+++ b/gltf-json/src/extensions/buffer.rs
@@ -1,10 +1,20 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// A buffer points to binary data representing geometry, animations, or skins.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Buffer {}
+pub struct Buffer {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// A view into a buffer generally representing a subset of the buffer.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct View {}
+pub struct View {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/camera.rs
+++ b/gltf-json/src/extensions/camera.rs
@@ -1,17 +1,31 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// A camera's projection.
 ///
 /// A node can reference a camera to apply a transform to place the camera in the
 /// scene.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Camera {}
+pub struct Camera {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// Values for an orthographic camera.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Orthographic {}
+pub struct Orthographic {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// Values for a perspective camera.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Perspective {}
+pub struct Perspective {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/image.rs
+++ b/gltf-json/src/extensions/image.rs
@@ -1,6 +1,12 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Image data used to create a texture.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Image {}
+pub struct Image {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -2,6 +2,8 @@
 use crate::{material::StrengthFactor, texture, validation::Validate, Extras};
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// The material appearance of a primitive.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
@@ -12,7 +14,7 @@ pub struct Material {
         rename = "KHR_materials_pbrSpecularGlossiness",
         skip_serializing_if = "Option::is_none"
     )]
-    pub pbr_specular_glossiness: Option<PbrSpecularGlossiness>,
+    pub pbr_specular_glossiness: Option<String>,
 
     #[cfg(feature = "KHR_materials_unlit")]
     #[serde(
@@ -61,12 +63,20 @@ pub struct Material {
         skip_serializing_if = "Option::is_none"
     )]
     pub emissive_strength: Option<EmissiveStrength>,
+
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
 }
 
 /// A set of parameter values that are used to define the metallic-roughness
 /// material model from Physically-Based Rendering (PBR) methodology.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct PbrMetallicRoughness {}
+pub struct PbrMetallicRoughness {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// A set of parameter values that are used to define the specular-glossiness
 /// material model from Physically-Based Rendering (PBR) methodology.
@@ -114,6 +124,10 @@ pub struct PbrSpecularGlossiness {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub specular_glossiness_texture: Option<texture::Info>,
 
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+
     /// Optional application specific data.
     #[cfg_attr(feature = "extras", serde(skip_serializing_if = "Option::is_none"))]
     #[cfg_attr(not(feature = "extras"), serde(skip_serializing))]
@@ -122,11 +136,19 @@ pub struct PbrSpecularGlossiness {
 
 /// Defines the normal texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct NormalTexture {}
+pub struct NormalTexture {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// Defines the occlusion texture of a material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct OcclusionTexture {}
+pub struct OcclusionTexture {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// The diffuse factor of a material.
 #[cfg(feature = "KHR_materials_pbrSpecularGlossiness")]

--- a/gltf-json/src/extensions/mesh.rs
+++ b/gltf-json/src/extensions/mesh.rs
@@ -1,12 +1,18 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// A set of primitives to be rendered.
 ///
 /// A node can contain one or more meshes and its transform places the meshes in
 /// the scene.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Mesh {}
+pub struct Mesh {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// Geometry to be rendered with the given material.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
@@ -18,6 +24,9 @@ pub struct Primitive {
         skip_serializing_if = "Option::is_none"
     )]
     pub khr_materials_variants: Option<KhrMaterialsVariants>,
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
 }
 
 #[cfg(feature = "KHR_materials_variants")]

--- a/gltf-json/src/extensions/root.rs
+++ b/gltf-json/src/extensions/root.rs
@@ -1,5 +1,7 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// The root object of a glTF 2.0 asset.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
@@ -19,6 +21,10 @@ pub struct Root {
         skip_serializing_if = "Option::is_none"
     )]
     pub khr_materials_variants: Option<KhrMaterialsVariants>,
+
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
 }
 
 #[cfg(feature = "KHR_lights_punctual")]

--- a/gltf-json/src/extensions/scene.rs
+++ b/gltf-json/src/extensions/scene.rs
@@ -1,5 +1,7 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// A node in the node hierarchy.  When the node contains `skin`, all
 /// `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.
@@ -20,6 +22,10 @@ pub struct Node {
         skip_serializing_if = "Option::is_none"
     )]
     pub khr_lights_punctual: Option<khr_lights_punctual::KhrLightsPunctual>,
+
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
 }
 
 #[cfg(feature = "KHR_lights_punctual")]
@@ -224,4 +230,8 @@ pub mod khr_materials_variants {
 
 /// The root `Node`s of a scene.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Scene {}
+pub struct Scene {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/skin.rs
+++ b/gltf-json/src/extensions/skin.rs
@@ -1,6 +1,12 @@
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Joints and matrices defining a skin.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Skin {}
+pub struct Skin {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}

--- a/gltf-json/src/extensions/texture.rs
+++ b/gltf-json/src/extensions/texture.rs
@@ -2,14 +2,24 @@
 use crate::{extras::Extras, validation::Validate};
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Texture sampler properties for filtering and wrapping modes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Sampler {}
+pub struct Sampler {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 /// A texture and its sampler.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
-pub struct Texture {}
+pub struct Texture {
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
+}
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 /// Reference to a `Texture`.
@@ -21,6 +31,9 @@ pub struct Info {
         skip_serializing_if = "Option::is_none"
     )]
     pub texture_transform: Option<TextureTransform>,
+    #[cfg(feature = "extensions")]
+    #[serde(default, flatten)]
+    pub others: Map<String, Value>,
 }
 
 /// Many techniques can be used to optimize resource usage for a 3d scene.

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -116,6 +116,19 @@ impl<K: ToString + Validate, V: Validate> Validate for BTreeMap<K, V> {
     }
 }
 
+impl Validate for serde_json::Map<String, serde_json::Value> {
+    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
+    where
+        P: Fn() -> Path,
+        R: FnMut(&dyn Fn() -> Path, Error),
+    {
+        for (key, value) in self.iter() {
+            key.validate(root, || path().key(&key.to_string()), report);
+            value.validate(root, || path().key(&key.to_string()), report);
+        }
+    }
+}
+
 impl<T: Validate> Validate for Option<T> {
     fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
     where

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -59,6 +59,8 @@ use crate::{buffer, Document};
 
 pub use json::accessor::ComponentType as DataType;
 pub use json::accessor::Type as Dimensions;
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Utility functions.
 #[cfg(feature = "utils")]
@@ -136,6 +138,22 @@ impl<'a> Accessor<'a> {
     /// Returns the data type of components in the attribute.
     pub fn data_type(&self) -> DataType {
         self.json.component_type.unwrap().0
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -4,6 +4,7 @@ use crate::{accessor, scene, Document};
 use crate::Buffer;
 
 pub use json::animation::{Interpolation, Property};
+use serde_json::{Map, Value};
 
 /// Iterators.
 pub mod iter;
@@ -109,6 +110,22 @@ impl<'a> Animation<'a> {
             anim: self.clone(),
             iter: self.json.samplers.iter(),
         }
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,6 +4,7 @@ use std::ops;
 use crate::Document;
 
 pub use json::buffer::Target;
+use serde_json::{Map, Value};
 
 /// A buffer points to binary data representing geometry, animations, or skins.
 #[derive(Clone, Debug)]
@@ -99,6 +100,22 @@ impl<'a> Buffer<'a> {
     #[cfg_attr(docsrs, doc(cfg(feature = "names")))]
     pub fn name(&self) -> Option<&'a str> {
         self.json.name.as_deref()
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -185,6 +185,22 @@ impl<'a> View<'a> {
         self.json.target.map(|target| target.unwrap())
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,8 @@
 use crate::Document;
 
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
+
 /// A camera's projection.
 #[derive(Clone, Debug)]
 pub enum Projection<'a> {
@@ -86,6 +89,22 @@ impl<'a> Camera<'a> {
         }
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
@@ -118,6 +137,22 @@ impl<'a> Orthographic<'a> {
         self.json.znear
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     ///  Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
@@ -148,6 +183,22 @@ impl<'a> Perspective<'a> {
     ///  The distance to the near clipping plane.
     pub fn znear(&self) -> f32 {
         self.json.znear
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     ///  Optional application specific data.

--- a/src/image.rs
+++ b/src/image.rs
@@ -4,6 +4,8 @@ use crate::{buffer, Document, Error, Result};
 #[cfg(feature = "import")]
 #[cfg_attr(docsrs, doc(cfg(feature = "import")))]
 use image_crate::DynamicImage;
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Format of image pixel data.
 #[cfg(feature = "import")]
@@ -127,6 +129,22 @@ impl<'a> Image<'a> {
             let mime_type = self.json.mime_type.as_ref().map(|x| x.0.as_str());
             Source::Uri { uri, mime_type }
         }
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,7 @@ impl Document {
     /// Returns the extension values map
     #[cfg(feature = "extensions")]
     #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
-    pub fn root_extensions(&self) -> Option<&Map<String, Value>> {
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
         let root = self.0.extensions.as_ref()?;
         Some(&root.others)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,11 @@ pub mod skin;
 /// Textures and their samplers.
 pub mod texture;
 
+#[cfg(feature = "extensions")]
+use json::Value;
+#[cfg(feature = "extensions")]
+use serde_json::Map;
+
 #[doc(inline)]
 pub use self::accessor::Accessor;
 #[doc(inline)]
@@ -439,6 +444,22 @@ impl Document {
             iter: self.0.images.iter().enumerate(),
             document: self,
         }
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn root_extensions(&self) -> Option<&Map<String, Value>> {
+        let root = self.0.extensions.as_ref()?;
+        Some(&root.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let root = self.0.extensions.as_ref()?;
+        root.others.get(ext_name)
     }
 
     /// Returns an `Iterator` that visits the lights of the glTF asset as defined by the

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,6 +1,8 @@
 use crate::{texture, Document};
 
 pub use json::material::AlphaMode;
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 lazy_static! {
     static ref DEFAULT_MATERIAL: json::material::Material = Default::default();
@@ -92,6 +94,22 @@ impl<'a> Material<'a> {
     /// Physically-Based Rendering (PBR) methodology.
     pub fn pbr_metallic_roughness(&self) -> PbrMetallicRoughness<'a> {
         PbrMetallicRoughness::new(self.document, &self.json.pbr_metallic_roughness)
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Get the value of an extension based on the name of the extension
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, key: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(key)
     }
 
     /// Parameter values that define the specular-glossiness material model from
@@ -300,6 +318,22 @@ impl<'a> PbrMetallicRoughness<'a> {
             let texture = self.document.textures().nth(json.index.value()).unwrap();
             texture::Info::new(texture, json)
         })
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Get the value of an extension based on the name of the extension
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, key: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(key)
     }
 
     /// Optional application specific data.
@@ -576,6 +610,22 @@ impl<'a> NormalTexture<'a> {
         self.texture.clone()
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Get the value of an extension based on the name of the extension
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, key: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(key)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
@@ -613,6 +663,22 @@ impl<'a> OcclusionTexture<'a> {
     /// Returns the referenced texture.
     pub fn texture(&self) -> texture::Texture<'a> {
         self.texture.clone()
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Get the value of an extension based on the name of the extension
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, key: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(key)
     }
 
     /// Optional application specific data.

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -63,6 +63,8 @@ use crate::accessor;
 
 pub use json::mesh::{Mode, Semantic};
 use json::validation::Checked;
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 /// Vertex attribute data.
 pub type Attribute<'a> = (Semantic, Accessor<'a>);
@@ -146,6 +148,22 @@ impl<'a> Mesh<'a> {
         self.index
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
@@ -195,6 +213,22 @@ impl<'a> Primitive<'a> {
         let min: [f32; 3] = json::deserialize::from_value(pos_accessor.min().unwrap()).unwrap();
         let max: [f32; 3] = json::deserialize::from_value(pos_accessor.max().unwrap()).unwrap();
         Bounds { min, max }
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
+
 use crate::math::*;
 use crate::{Camera, Document, Mesh, Skin};
 
@@ -142,6 +145,22 @@ impl<'a> Node<'a> {
         }
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
@@ -224,6 +243,22 @@ impl<'a> Scene<'a> {
     /// Returns the internal JSON index.
     pub fn index(&self) -> usize {
         self.index
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
+
 use crate::{Accessor, Document, Node};
 
 #[cfg(feature = "utils")]
@@ -41,6 +44,22 @@ impl<'a> Skin<'a> {
     /// Returns the internal JSON index.
     pub fn index(&self) -> usize {
         self.index
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,6 +1,8 @@
 use crate::{image, Document};
 
 pub use json::texture::{MagFilter, MinFilter, WrappingMode};
+#[cfg(feature = "extensions")]
+use serde_json::{Map, Value};
 
 lazy_static! {
     static ref DEFAULT_SAMPLER: json::texture::Sampler = Default::default();
@@ -99,6 +101,22 @@ impl<'a> Sampler<'a> {
         self.json.wrap_t.unwrap()
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &json::Extras {
         &self.json.extras
@@ -147,6 +165,22 @@ impl<'a> Texture<'a> {
             .unwrap()
     }
 
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
+    }
+
     /// Optional application specific data.
     pub fn extras(&self) -> &json::Extras {
         &self.json.extras
@@ -179,6 +213,22 @@ impl<'a> Info<'a> {
             .texture_transform
             .as_ref()
             .map(TextureTransform::new)
+    }
+
+    /// Returns the extension values map
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn extensions(&self) -> Option<&Map<String, Value>> {
+        let ext = self.json.extensions.as_ref()?;
+        Some(&ext.others)
+    }
+
+    /// Return a value for a given extension name
+    #[cfg(feature = "extensions")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "extensions")))]
+    pub fn get_extension_value(&self, ext_name: &str) -> Option<&Value> {
+        let ext = self.json.extensions.as_ref()?;
+        ext.others.get(ext_name)
     }
 
     /// Optional application specific data.


### PR DESCRIPTION
Fixes #231 

You can access the extensions in the following manner:
```rs
//materials extension, same for all fields
for value in gltf.materials() {
    if let Some(ext) = value.extensions() {
        for values in ext {
            println!("{},{}", values.0, values.1)
        }
    }
}

//root extensions
gltf.extensions();

//or you can use get_extension_value() for a single value instead of the whole map
for value in gltf.materials() {
    println!(
        "{}",
        value.get_extension_value("VRMC_materials_mtoon").unwrap()
    )
}
```