### PR TITLE
Allow handling large external buffers

### DIFF
--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -71,7 +71,7 @@ fn export(output: Output) {
 
     let (min, max) = bounding_coords(&triangle_vertices);
 
-    let buffer_length = (triangle_vertices.len() * mem::size_of::<Vertex>()) as u32;
+    let buffer_length = (triangle_vertices.len() * mem::size_of::<Vertex>()) as u64;
     let buffer = json::Buffer {
         byte_length: buffer_length,
         extensions: Default::default(),
@@ -87,7 +87,7 @@ fn export(output: Output) {
         buffer: json::Index::new(0),
         byte_length: buffer.byte_length,
         byte_offset: None,
-        byte_stride: Some(mem::size_of::<Vertex>() as u32),
+        byte_stride: Some(mem::size_of::<Vertex>() as u64),
         extensions: Default::default(),
         extras: Default::default(),
         name: None,
@@ -198,7 +198,7 @@ fn export(output: Output) {
                 header: gltf::binary::Header {
                     magic: *b"glTF",
                     version: 2,
-                    length: json_offset + buffer_length,
+                    length: json_offset + buffer_length as u32, // This may truncate long buffers
                 },
                 bin: Some(Cow::Owned(to_padded_byte_vector(triangle_vertices))),
                 json: Cow::Owned(json_string.into_bytes()),

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -47,7 +47,7 @@ impl ser::Serialize for Target {
 pub struct Buffer {
     /// The length of the buffer in bytes.
     #[serde(default, rename = "byteLength")]
-    pub byte_length: u32,
+    pub byte_length: u64,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
@@ -81,7 +81,7 @@ pub struct View {
 
     /// The length of the `BufferView` in bytes.
     #[serde(rename = "byteLength")]
-    pub byte_length: u32,
+    pub byte_length: u64,
 
     /// Offset into the parent buffer in bytes.
     #[serde(
@@ -89,14 +89,14 @@ pub struct View {
         rename = "byteOffset",
         skip_serializing_if = "Option::is_none"
     )]
-    pub byte_offset: Option<u32>,
+    pub byte_offset: Option<u64>,
 
     /// The stride in bytes between vertex attributes or other interleavable data.
     ///
     /// When zero, data is assumed to be tightly packed.
     #[serde(rename = "byteStride")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub byte_stride: Option<u32>,
+    pub byte_stride: Option<u64>,
 
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -182,6 +182,7 @@ impl std::fmt::Display for Error {
 // These types are assumed to be always valid.
 impl Validate for bool {}
 impl Validate for u32 {}
+impl Validate for u64 {}
 impl Validate for i32 {}
 impl Validate for f32 {}
 impl Validate for [f32; 3] {}

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -8,8 +8,8 @@ fn buffer_view_slice<'a, 's>(
     view: buffer::View<'a>,
     get_buffer_data: &dyn Fn(buffer::Buffer<'a>) -> Option<&'s [u8]>,
 ) -> Option<&'s [u8]> {
-    let start = view.offset();
-    let end = start + view.length();
+    let start = usize::try_from(view.offset()).ok()?;
+    let end = usize::try_from(start as u64 + view.length()).ok()?;
     get_buffer_data(view.buffer()).and_then(|slice| slice.get(start..end))
 }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -4,6 +4,7 @@ use crate::{accessor, scene, Document};
 use crate::Buffer;
 
 pub use json::animation::{Interpolation, Property};
+#[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
 /// Iterators.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,6 +4,7 @@ use std::ops;
 use crate::Document;
 
 pub use json::buffer::Target;
+#[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
 /// A buffer points to binary data representing geometry, animations, or skins.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -92,8 +92,8 @@ impl<'a> Buffer<'a> {
     }
 
     /// The length of the buffer in bytes.
-    pub fn length(&self) -> usize {
-        self.json.byte_length as usize
+    pub fn length(&self) -> u64 {
+        self.json.byte_length
     }
 
     /// Optional user-defined name for this object.
@@ -151,13 +151,13 @@ impl<'a> View<'a> {
     }
 
     /// Returns the length of the buffer view in bytes.
-    pub fn length(&self) -> usize {
-        self.json.byte_length as usize
+    pub fn length(&self) -> u64 {
+        self.json.byte_length
     }
 
     /// Returns the offset into the parent buffer in bytes.
-    pub fn offset(&self) -> usize {
-        self.json.byte_offset.unwrap_or(0) as usize
+    pub fn offset(&self) -> u64 {
+        self.json.byte_offset.unwrap_or(0)
     }
 
     /// Returns the stride in bytes between vertex attributes or other interleavable

--- a/src/import.rs
+++ b/src/import.rs
@@ -123,11 +123,11 @@ pub fn import_buffers(
     let mut buffers = Vec::new();
     for buffer in document.buffers() {
         let data = buffer::Data::from_source_and_blob(buffer.source(), base, &mut blob)?;
-        if data.len() < buffer.length() {
+        if (data.len() as u64) < buffer.length() {
             return Err(Error::BufferLength {
                 buffer: buffer.index(),
                 expected: buffer.length(),
-                actual: data.len(),
+                actual: data.len() as u64,
             });
         }
         buffers.push(data);
@@ -191,8 +191,10 @@ impl image::Data {
             },
             image::Source::View { view, mime_type } => {
                 let parent_buffer_data = &buffer_data[view.buffer().index()].0;
-                let begin = view.offset();
-                let end = begin + view.length();
+                let begin = usize::try_from(view.offset())
+                    .map_err(|_| Error::OverlargeBuffer(view.offset()))?;
+                let end = usize::try_from(begin as u64 + view.length())
+                    .map_err(|_| Error::OverlargeBuffer(begin as u64 + view.offset()))?;
                 let encoded_image = &parent_buffer_data[begin..end];
                 let encoded_format = match mime_type {
                     "image/png" => Png,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,10 +213,10 @@ pub enum Error {
         buffer: usize,
 
         /// The expected buffer length in bytes.
-        expected: usize,
+        expected: u64,
 
         /// The number of bytes actually available.
-        actual: usize,
+        actual: u64,
     },
 
     /// JSON deserialization error.
@@ -257,6 +257,9 @@ pub enum Error {
 
     /// glTF validation error.
     Validation(Vec<(json::Path, json::validation::Error)>),
+
+    /// buffer size does not fit in target platform usize type
+    OverlargeBuffer(u64),
 }
 
 /// glTF JSON wrapper plus binary payload.
@@ -613,6 +616,10 @@ impl std::fmt::Display for Error {
                 }
                 Ok(())
             }
+            Error::OverlargeBuffer(n) => write!(
+                f,
+                "buffer with size over {n} exceeds platform address space"
+            ),
         }
     }
 }


### PR DESCRIPTION
Closes #393 

I've added a new error type for it to make failures explicit, but you could arguably also just use `as usize` and live with potentially weird behaviour when large values are truncated. Presumably, in those cases you'd crash anyway when trying to load the data into memory, though I haven't looked into it more.

I've also silenced some warnings in a separate commit by hiding them behind a `cfg` tag because they annoyed me during development, but I'm happy to remove those changes if you prefer.