### PR TITLE
`impl Default for gltf_json::Node`.

### DIFF
--- a/examples/export/main.rs
+++ b/examples/export/main.rs
@@ -151,18 +151,8 @@ fn export(output: Output) {
     };
 
     let node = json::Node {
-        camera: None,
-        children: None,
-        extensions: Default::default(),
-        extras: Default::default(),
-        matrix: None,
         mesh: Some(json::Index::new(0)),
-        name: None,
-        rotation: None,
-        scale: None,
-        translation: None,
-        skin: None,
-        weights: None,
+        ..Default::default()
     };
 
     let root = json::Root {

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -13,7 +13,7 @@ use serde_derive::{Deserialize, Serialize};
 /// identity. When a node is targeted for animation (referenced by an
 /// animation.channel.target), only TRS properties may be present; `matrix` will not
 /// be present.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Node {
     /// The index of the camera referenced by this node.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Since `Node`s are generally expected to have only a few non-absent fields, providing this `Default` implementation will allow code that is generating `Node`s to be much more concise.