### PR TITLE
Add non-consuming `as_json` method to `Document` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,11 @@ impl Document {
         self.0
     }
 
+    /// Unwraps the glTF document, without consuming it.
+    pub fn as_json(&self) -> &json::Root {
+        &self.0
+    }
+
     /// Perform validation checks on loaded glTF.
     pub(crate) fn validate(&self) -> Result<()> {
         use json::validation::Validate;


### PR DESCRIPTION
Currently, when serializing a glTF `Document`, the responsible code must own the `Document` to call the `into_json` method. However, this requirement deviates from the usual read-only borrow requirement for serializing data. To overcome this, client code can arrange for passing around references to the inner `Root` struct, but doing so sacrifices the benefits provided by the `Gltf` and `Document` structs for better binary data handling. (The `Deref` implementation for `Gltf` can also be used, but its syntax is somewhat unintuitive, and that does not apply to `Document`s themselves.)

To improve on this, let's introduce a non-consuming `as_json` unwrapping method. This method takes the `Document` by reference and returns a reference to the inner `Root` structure. By doing this, its usage across various use cases is simplified, making the code more straightforward and intuitive.