### PR TITLE
Fix size hint and values read with sparse iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Fix `attemt to to subtract with overflow`-panic in `size_hint()` of sparse accessor when collecting items.
+- Fix incorrect values returned from `size_hint()` in sparse accessor
+- Add support to read items from sparse accessor without base buffer view
+
 ## [1.4.0] - 2023-12-17
 
 ### Added

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -145,8 +145,11 @@ impl<'a, T: Item> Iterator for SparseIter<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let hint = self.values.len() - self.counter as usize;
-        (hint, Some(hint))
+        if let Some(base) = self.base.as_ref() {
+            base.size_hint()
+        } else {
+            self.values.size_hint()
+        }
     }
 }
 

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -94,6 +94,11 @@ pub struct SparseIter<'a, T: Item> {
     /// This can be `None` if the base buffer view is not set. In this case the base values are all zero.
     base: Option<ItemIter<'a, T>>,
 
+    /// Number of values in the base accessor
+    ///
+    /// Valid even when `base` is not set.
+    base_count: usize,
+
     /// Sparse indices iterator.
     indices: iter::Peekable<SparseIndicesIter<'a>>,
 
@@ -110,11 +115,13 @@ impl<'a, T: Item> SparseIter<'a, T> {
     /// Here `base` is allowed to be `None` when the base buffer view is not explicitly specified.
     pub fn new(
         base: Option<ItemIter<'a, T>>,
+        base_count: usize,
         indices: SparseIndicesIter<'a>,
         values: ItemIter<'a, T>,
     ) -> Self {
         SparseIter {
             base,
+            base_count,
             indices: indices.peekable(),
             values,
             counter: 0,
@@ -125,11 +132,17 @@ impl<'a, T: Item> SparseIter<'a, T> {
 impl<'a, T: Item> Iterator for SparseIter<'a, T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
-        let mut next_value = self
-            .base
-            .as_mut()
-            .map(|iter| iter.next())
-            .unwrap_or_else(|| Some(T::zero()))?;
+        let mut next_value = if let Some(base) = self.base.as_mut() {
+            // If accessor.bufferView is set we let base decide when we have reached the end
+            // of the iteration sequence.
+            base.next()?
+        } else if (self.counter as usize) < self.base_count {
+            // Else, we continue iterating until we have generated the number of items
+            // specified by accessor.count
+            T::zero()
+        } else {
+            return None;
+        };
 
         let next_sparse_index = self.indices.peek();
         if let Some(index) = next_sparse_index {
@@ -145,11 +158,8 @@ impl<'a, T: Item> Iterator for SparseIter<'a, T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if let Some(base) = self.base.as_ref() {
-            base.size_hint()
-        } else {
-            self.values.size_hint()
-        }
+        let hint = self.base_count - (self.counter as usize).min(self.base_count);
+        (hint, Some(hint))
     }
 }
 
@@ -303,6 +313,7 @@ impl<'a, 's, T: Item> Iter<'s, T> {
                 } else {
                     None
                 };
+                let base_count = accessor.count();
 
                 let indices = sparse.indices();
                 let values = sparse.values();
@@ -344,7 +355,7 @@ impl<'a, 's, T: Item> Iter<'s, T> {
                 };
 
                 Some(Iter::Sparse(SparseIter::new(
-                    base_iter, index_iter, value_iter,
+                    base_iter, base_count, index_iter, value_iter,
                 )))
             }
             None => {

--- a/tests/test_wrapper.rs
+++ b/tests/test_wrapper.rs
@@ -106,3 +106,23 @@ fn test_sparse_accessor_without_base_buffer_view_yield_exact_size_hints() {
         outputs_iter.next();
     }
 }
+
+#[test]
+fn test_sparse_accessor_without_base_buffer_view_yield_all_values() {
+    let (document, buffers, _) = gltf::import(BOX_SPARSE_GLTF).unwrap();
+
+    let animation = document.animations().next().unwrap();
+    let sampler = animation.samplers().next().unwrap();
+    let output_accessor = sampler.output();
+    let output_iter = gltf::accessor::Iter::<f32>::new(output_accessor, |buffer: gltf::Buffer| {
+        buffers.get(buffer.index()).map(|data| &data.0[..])
+    })
+    .unwrap();
+    let outputs = output_iter.collect::<Vec<_>>();
+
+    const EXPECTED_OUTPUTS: [f32; 2] = [0.0, 1.0];
+    assert_eq!(outputs.len(), EXPECTED_OUTPUTS.len());
+    for (i, o) in outputs.iter().enumerate() {
+        assert_eq!(o - EXPECTED_OUTPUTS[i], 0.0);
+    }
+}


### PR DESCRIPTION
In #313 @wsw0108 shows that collecting positions specified using a sparse accessor triggers a panic (`attempt to subtract with overflow`) inside of `size_hint()` of `SparseIter`.

In this PR I have rewritten the code in the issue as two unit tests, one that verifies `size_hint()` and one that verifies that the positions are actually correct. Both tests fail when using latest `main`.

The `SimpleSparseAccessor.gltf` test asset contains 14 positions specified in a sparse accessor where three of them is overrideen by values specified in the sparse section of the accessor. Look at the data layout image here for an overview: [gltf-test/tutorialModels/SimpleSparseAccessor][1].

The two tests pass after delegating the `size_hint()` call to the iterator for the base accessor, it knows how many items are left.

The gltf specification on [Sparse Accessors][2] mentions that a sparse accessor may not have a `bufferView` set
> When accessor.bufferView is undefined, the sparse accessor is initialized as an array of zeros of size (size of the accessor element) * (accessor.count) bytes.

For `SparseIter`, `base` will not be set and `size_hint()` cannot rely on it anymore. The solution is simple, simply pass `accessor.count` to `SparseIter` so that it can use it to know how many items there are. Then it simply deducts `self.counter` from it as that variable keeps track of how many items have been read from the iterator.

The asset `tests/box_sparse.gltf` contains a sparse accessor without a base buffer view. This is used in two unit tests that the behavior is correct, even for these sorts of accessors.

[1]: https://github.com/cx20/gltf-test/tree/master/tutorialModels/SimpleSparseAccessor
[2]: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#sparse-accessors