### PR TITLE
Bump image to 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The `gltf` crate adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix incorrect values returned from `size_hint()` in sparse accessor
 - Add support to read items from sparse accessor without base buffer view
 
+### Changed
+- Update `image` to `0.25.0`. 
+
+### Removed
+- Feature `image_jpeg_rayon` no longer needed, as `image 0.25.0` now uses `zune-jpeg` for jpeg decoding.
+
 ## [1.4.0] - 2023-12-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { features = ["raw_value"], version = "1.0" }
 default-features = false
 features = ["jpeg", "png"]
 optional = true
-version = "0.24"
+version = "0.25"
 
 [features]
 default = ["import", "utils", "names"]
@@ -53,7 +53,6 @@ KHR_materials_variants = ["gltf-json/KHR_materials_variants"]
 KHR_materials_volume = ["gltf-json/KHR_materials_volume"]
 KHR_materials_specular = ["gltf-json/KHR_materials_specular"]
 KHR_materials_emissive_strength = ["gltf-json/KHR_materials_emissive_strength"]
-image_jpeg_rayon = ["image/jpeg_rayon"]
 guess_mime_type = []
 
 [[example]]


### PR DESCRIPTION
`image` released a `0.25.0` version. Most notably, they switched the jpeg decoder backend to `zune-jpeg` and removed the feature `jpeg_rayon`. This PR updates `image` and removes the associated `image_jpeg_rayon` feature. All tests pass. I have not seen other relevant changes in the `image` release notes for `gltf` but I'm not familiar with the codebase.