### PR TITLE
feat: Channel and Sampler return their index with .index(). Fixes #398

### DIFF
--- a/src/animation/iter.rs
+++ b/src/animation/iter.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use std::{iter, slice};
 
 use crate::animation::{Animation, Channel, Sampler};
 
@@ -9,7 +9,7 @@ pub struct Channels<'a> {
     pub(crate) anim: Animation<'a>,
 
     /// The internal channel iterator.
-    pub(crate) iter: slice::Iter<'a, json::animation::Channel>,
+    pub(crate) iter: iter::Enumerate<slice::Iter<'a, json::animation::Channel>>,
 }
 
 /// An `Iterator` that visits the samplers of an animation.
@@ -19,7 +19,7 @@ pub struct Samplers<'a> {
     pub(crate) anim: Animation<'a>,
 
     /// The internal channel iterator.
-    pub(crate) iter: slice::Iter<'a, json::animation::Sampler>,
+    pub(crate) iter: iter::Enumerate<slice::Iter<'a, json::animation::Sampler>>,
 }
 
 impl<'a> Iterator for Channels<'a> {
@@ -27,7 +27,7 @@ impl<'a> Iterator for Channels<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter
             .next()
-            .map(|json| Channel::new(self.anim.clone(), json))
+            .map(|(index, json)| Channel::new(self.anim.clone(), json, index))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
@@ -37,12 +37,14 @@ impl<'a> Iterator for Channels<'a> {
     }
     fn last(self) -> Option<Self::Item> {
         let anim = self.anim;
-        self.iter.last().map(|json| Channel::new(anim, json))
+        self.iter
+            .last()
+            .map(|(index, json)| Channel::new(anim, json, index))
     }
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.iter
             .nth(n)
-            .map(|json| Channel::new(self.anim.clone(), json))
+            .map(|(index, json)| Channel::new(self.anim.clone(), json, index))
     }
 }
 
@@ -51,7 +53,7 @@ impl<'a> Iterator for Samplers<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter
             .next()
-            .map(|json| Sampler::new(self.anim.clone(), json))
+            .map(|(index, json)| Sampler::new(self.anim.clone(), json, index))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
@@ -61,11 +63,13 @@ impl<'a> Iterator for Samplers<'a> {
     }
     fn last(self) -> Option<Self::Item> {
         let anim = self.anim;
-        self.iter.last().map(|json| Sampler::new(anim, json))
+        self.iter
+            .last()
+            .map(|(index, json)| Sampler::new(anim, json, index))
     }
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         self.iter
             .nth(n)
-            .map(|json| Sampler::new(self.anim.clone(), json))
+            .map(|(index, json)| Sampler::new(self.anim.clone(), json, index))
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -38,6 +38,9 @@ pub struct Channel<'a> {
     /// The parent `Animation` struct.
     anim: Animation<'a>,
 
+    /// The corresponding JSON index.
+    index: usize,
+
     /// The corresponding JSON struct.
     json: &'a json::animation::Channel,
 }
@@ -47,6 +50,9 @@ pub struct Channel<'a> {
 pub struct Sampler<'a> {
     /// The parent `Animation` struct.
     anim: Animation<'a>,
+
+    /// The corresponding JSON index.
+    index: usize,
 
     /// The corresponding JSON struct.
     json: &'a json::animation::Sampler,
@@ -92,7 +98,7 @@ impl<'a> Animation<'a> {
     pub fn channels(&self) -> iter::Channels<'a> {
         iter::Channels {
             anim: self.clone(),
-            iter: self.json.channels.iter(),
+            iter: self.json.channels.iter().enumerate(),
         }
     }
 
@@ -109,7 +115,7 @@ impl<'a> Animation<'a> {
     pub fn samplers(&self) -> iter::Samplers<'a> {
         iter::Samplers {
             anim: self.clone(),
-            iter: self.json.samplers.iter(),
+            iter: self.json.samplers.iter().enumerate(),
         }
     }
 
@@ -132,8 +138,12 @@ impl<'a> Animation<'a> {
 
 impl<'a> Channel<'a> {
     /// Constructs a `Channel`.
-    pub(crate) fn new(anim: Animation<'a>, json: &'a json::animation::Channel) -> Self {
-        Self { anim, json }
+    pub(crate) fn new(
+        anim: Animation<'a>,
+        json: &'a json::animation::Channel,
+        index: usize,
+    ) -> Self {
+        Self { anim, json, index }
     }
 
     /// Returns the parent `Animation` struct.
@@ -168,6 +178,11 @@ impl<'a> Channel<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Returns the internal JSON index.
+    pub fn index(&self) -> usize {
+        self.index
     }
 }
 
@@ -205,8 +220,12 @@ impl<'a> Target<'a> {
 
 impl<'a> Sampler<'a> {
     /// Constructs a `Sampler`.
-    pub(crate) fn new(anim: Animation<'a>, json: &'a json::animation::Sampler) -> Self {
-        Self { anim, json }
+    pub(crate) fn new(
+        anim: Animation<'a>,
+        json: &'a json::animation::Sampler,
+        index: usize,
+    ) -> Self {
+        Self { anim, json, index }
     }
 
     /// Returns the parent `Animation` struct.
@@ -217,6 +236,11 @@ impl<'a> Sampler<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Returns the internal JSON index.
+    pub fn index(&self) -> usize {
+        self.index
     }
 
     /// Returns the accessor containing the keyframe input values (e.g. time).


### PR DESCRIPTION
This adds `.index()` to `gltf::animation::Channel` and `gltf::animation::Sampler`.

This should fix #398.