### PR TITLE
fix: PbrBaseColorFactor is optional

### DIFF
--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -135,7 +135,8 @@ pub struct Material {
 pub struct PbrMetallicRoughness {
     /// The material's base color factor.
     #[serde(rename = "baseColorFactor")]
-    pub base_color_factor: PbrBaseColorFactor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_color_factor: Option<PbrBaseColorFactor>,
 
     /// The base color texture.
     #[serde(rename = "baseColorTexture")]

--- a/src/material.rs
+++ b/src/material.rs
@@ -278,7 +278,7 @@ impl<'a> PbrMetallicRoughness<'a> {
     ///
     /// The default value is `[1.0, 1.0, 1.0, 1.0]`.
     pub fn base_color_factor(&self) -> [f32; 4] {
-        self.json.base_color_factor.0
+        self.json.base_color_factor.unwrap_or(json::material::PbrBaseColorFactor([1.0, 1.0, 1.0, 1.0])).0
     }
 
     /// Returns the base color texture. The texture contains RGB(A) components


### PR DESCRIPTION
as per the [documentation](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_material_pbrmetallicroughness_basecolorfactor), the baseColorFactor field is not required