### PR TITLE
Mention that EXT_texture_webp is supported in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following glTF extensions are supported by the crate:
 - `KHR_materials_transmission`
 - `KHR_materials_ior`
 - `KHR_materials_emissive_strength `
+- `EXT_texture_webp`
 
 To use an extension, list its name in the `features` section.
 


### PR DESCRIPTION
Was reading the readme and thought webp was unsupported, but after some quick greps, it seems like it is actually supported. Made it clear in the readme.