### PR TITLE
implement PartialEq on Root and its attributes

### DIFF
--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -83,7 +83,7 @@ pub mod sparse {
     use crate::extensions;
 
     /// Indices of those attributes that deviate from their initialization value.
-    #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Indices {
         /// The parent buffer view containing the sparse indices.
         ///
@@ -112,7 +112,7 @@ pub mod sparse {
     }
 
     /// Sparse storage of attributes that deviate from their initialization value.
-    #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Sparse {
         /// The number of attributes encoded in this sparse accessor.
         pub count: USize64,
@@ -143,7 +143,7 @@ pub mod sparse {
 
     /// Array of size `count * number_of_components` storing the displaced
     /// accessor attributes pointed by `accessor::sparse::Indices`.
-    #[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Values {
         /// The parent buffer view containing the sparse indices.
         ///
@@ -169,7 +169,7 @@ pub mod sparse {
 }
 
 /// A typed view into a buffer view.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 #[gltf(validate_hook = "accessor_validate_hook")]
 pub struct Accessor {
     /// The parent buffer view this accessor reads from.
@@ -250,11 +250,11 @@ fn is_normalized_default(b: &bool) -> bool {
 }
 
 /// The data type of an index.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct IndexComponentType(pub ComponentType);
 
 /// The data type of a generic vertex attribute.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct GenericComponentType(pub ComponentType);
 
 impl<'de> de::Deserialize<'de> for Checked<GenericComponentType> {

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -53,7 +53,7 @@ pub enum Property {
 }
 
 /// A keyframe animation.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Animation {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -84,7 +84,7 @@ pub struct Animation {
 }
 
 /// Targets an animation's sampler at a node's property.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Channel {
     /// The index of a sampler in this animation used to compute the value for the
     /// target.
@@ -105,7 +105,7 @@ pub struct Channel {
 }
 
 /// The index of the node and TRS property that an animation channel targets.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Target {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -126,7 +126,7 @@ pub struct Target {
 }
 
 /// Defines a keyframe graph but not its target.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Sampler {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/gltf-json/src/asset.rs
+++ b/gltf-json/src/asset.rs
@@ -3,7 +3,7 @@ use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 
 /// Metadata about the glTF asset.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Asset {
     /// A copyright message suitable for display to credit the content creator.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -59,7 +59,7 @@ impl Validate for Stride {
 }
 
 /// A buffer points to binary data representing geometry, animations, or skins.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Buffer {
     /// The length of the buffer in bytes.
     #[serde(default, rename = "byteLength")]
@@ -90,7 +90,7 @@ pub struct Buffer {
 ///
 /// <https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-bufferview>
 ///
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct View {
     /// The parent `Buffer`.
     pub buffer: Index<Buffer>,

--- a/gltf-json/src/camera.rs
+++ b/gltf-json/src/camera.rs
@@ -22,7 +22,7 @@ pub enum Type {
 ///
 /// A node can reference a camera to apply a transform to place the camera in the
 /// scene.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 #[gltf(validate_hook = "camera_validate_hook")]
 pub struct Camera {
     /// Optional user-defined name for this object.
@@ -66,7 +66,7 @@ where
 }
 
 /// Values for an orthographic camera.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Orthographic {
     /// The horizontal magnification of the view.
     pub xmag: f32,
@@ -92,7 +92,7 @@ pub struct Orthographic {
 }
 
 /// Values for a perspective camera.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Perspective {
     /// Aspect ratio of the field of view.
     #[serde(rename = "aspectRatio")]

--- a/gltf-json/src/extensions/accessor.rs
+++ b/gltf-json/src/extensions/accessor.rs
@@ -8,21 +8,21 @@ pub mod sparse {
     use super::*;
 
     /// Indices of those attributes that deviate from their initialization value.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Indices {}
 
     /// Sparse storage of attributes that deviate from their initialization value.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Sparse {}
 
     /// Array of size `count * number_of_components` storing the displaced
     /// accessor attributes pointed by `accessor::sparse::Indices`.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
     pub struct Values {}
 }
 
 /// A typed view into a buffer view.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Accessor {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/animation.rs
+++ b/gltf-json/src/extensions/animation.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// A keyframe animation.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Animation {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -12,13 +12,13 @@ pub struct Animation {
 }
 
 /// Targets an animation's sampler at a node's property.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Channel {}
 
 /// The index of the node and TRS property that an animation channel targets.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Target {}
 
 /// Defines a keyframe graph but not its target.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Sampler {}

--- a/gltf-json/src/extensions/asset.rs
+++ b/gltf-json/src/extensions/asset.rs
@@ -2,5 +2,5 @@ use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 
 /// Metadata about the glTF asset.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Asset {}

--- a/gltf-json/src/extensions/buffer.rs
+++ b/gltf-json/src/extensions/buffer.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// A buffer points to binary data representing geometry, animations, or skins.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Buffer {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -12,7 +12,7 @@ pub struct Buffer {
 }
 
 /// A view into a buffer generally representing a subset of the buffer.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct View {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/camera.rs
+++ b/gltf-json/src/extensions/camera.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value};
 ///
 /// A node can reference a camera to apply a transform to place the camera in the
 /// scene.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Camera {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -15,7 +15,7 @@ pub struct Camera {
 }
 
 /// Values for an orthographic camera.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Orthographic {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -23,7 +23,7 @@ pub struct Orthographic {
 }
 
 /// Values for a perspective camera.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Perspective {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/image.rs
+++ b/gltf-json/src/extensions/image.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// Image data used to create a texture.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Image {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -6,7 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// The material appearance of a primitive.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Material {
     #[cfg(feature = "KHR_materials_pbrSpecularGlossiness")]
     #[serde(
@@ -71,7 +71,7 @@ pub struct Material {
 
 /// A set of parameter values that are used to define the metallic-roughness
 /// material model from Physically-Based Rendering (PBR) methodology.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct PbrMetallicRoughness {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -135,7 +135,7 @@ pub struct PbrSpecularGlossiness {
 }
 
 /// Defines the normal texture of a material.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct NormalTexture {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -143,7 +143,7 @@ pub struct NormalTexture {
 }
 
 /// Defines the occlusion texture of a material.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct OcclusionTexture {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/mesh.rs
+++ b/gltf-json/src/extensions/mesh.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value};
 ///
 /// A node can contain one or more meshes and its transform places the meshes in
 /// the scene.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Mesh {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -15,7 +15,7 @@ pub struct Mesh {
 }
 
 /// Geometry to be rendered with the given material.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Primitive {
     #[cfg(feature = "KHR_materials_variants")]
     #[serde(

--- a/gltf-json/src/extensions/root.rs
+++ b/gltf-json/src/extensions/root.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// The root object of a glTF 2.0 asset.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Root {
     #[cfg(feature = "KHR_lights_punctual")]
     #[serde(

--- a/gltf-json/src/extensions/scene.rs
+++ b/gltf-json/src/extensions/scene.rs
@@ -13,7 +13,7 @@ use serde_json::{Map, Value};
 /// identity. When a node is targeted for animation (referenced by an
 /// animation.channel.target), only TRS properties may be present; `matrix` will not
 /// be present.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Node {
     #[cfg(feature = "KHR_lights_punctual")]
     #[serde(
@@ -222,7 +222,7 @@ pub mod khr_materials_variants {
 }
 
 /// The root `Node`s of a scene.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Scene {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/skin.rs
+++ b/gltf-json/src/extensions/skin.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// Joints and matrices defining a skin.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Skin {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]

--- a/gltf-json/src/extensions/texture.rs
+++ b/gltf-json/src/extensions/texture.rs
@@ -9,7 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 /// Texture sampler properties for filtering and wrapping modes.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Sampler {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -17,7 +17,7 @@ pub struct Sampler {
 }
 
 /// A texture and its sampler.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Texture {
     #[cfg(feature = "extensions")]
     #[serde(default, flatten)]
@@ -39,7 +39,7 @@ pub struct TextureWebp {
     pub source: Index<image::Image>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 /// Reference to a `Texture`.
 pub struct Info {
     #[cfg(feature = "KHR_texture_transform")]

--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -14,7 +14,7 @@ pub type Extras = Option<::std::boxed::Box<RawValue>>;
 pub type Extras = Void;
 
 /// Type representing no user-defined data.
-#[derive(Clone, Default, Serialize, Deserialize, Validate)]
+#[derive(Clone, Default, Serialize, Deserialize, Validate, PartialEq)]
 pub struct Void {
     #[serde(default, skip_serializing)]
     _allow_unknown_fields: (),

--- a/gltf-json/src/image.rs
+++ b/gltf-json/src/image.rs
@@ -12,7 +12,7 @@ pub const VALID_MIME_TYPES: &[&str] = &[
 ];
 
 /// Image data used to create a texture.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Image {
     /// The index of the buffer view that contains the image. Use this instead of
     /// the image's uri property.
@@ -48,7 +48,7 @@ pub struct Image {
 }
 
 /// An image MIME type.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct MimeType(pub String);
 
 impl Validate for MimeType {}

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -37,7 +37,7 @@ impl ser::Serialize for AlphaMode {
 }
 
 /// The material appearance of a primitive.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 #[serde(default)]
 pub struct Material {
     /// The alpha cutoff value of the material.
@@ -130,7 +130,7 @@ pub struct Material {
 
 /// A set of parameter values that are used to define the metallic-roughness
 /// material model from Physically-Based Rendering (PBR) methodology.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 #[serde(default)]
 pub struct PbrMetallicRoughness {
     /// The material's base color factor.
@@ -176,7 +176,7 @@ pub struct PbrMetallicRoughness {
 }
 
 /// Defines the normal texture of a material.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct NormalTexture {
     /// The index of the texture.
     pub index: Index<texture::Texture>,
@@ -207,7 +207,7 @@ fn material_normal_texture_scale_default() -> f32 {
 }
 
 /// Defines the occlusion texture of a material.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct OcclusionTexture {
     /// The index of the texture.
     pub index: Index<texture::Texture>,
@@ -232,19 +232,19 @@ pub struct OcclusionTexture {
 }
 
 /// The alpha cutoff value of a material.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct AlphaCutoff(pub f32);
 
 /// The emissive color of a material.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct EmissiveFactor(pub [f32; 3]);
 
 /// The base color factor of a material.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct PbrBaseColorFactor(pub [f32; 4]);
 
 /// A number in the inclusive range [0.0, 1.0] with a default value of 1.0.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct StrengthFactor(pub f32);
 
 impl Default for AlphaCutoff {

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -71,7 +71,7 @@ pub enum Mode {
 ///
 /// A node can contain one or more meshes and its transform places the meshes in
 /// the scene.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Mesh {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -97,7 +97,7 @@ pub struct Mesh {
 }
 
 /// Geometry to be rendered with the given material.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 #[gltf(validate_hook = "primitive_validate_hook")]
 pub struct Primitive {
     /// Maps attribute semantic names to the `Accessor`s containing the
@@ -173,7 +173,7 @@ where
 }
 
 /// A dictionary mapping attributes to their deviations in the Morph Target.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct MorphTarget {
     /// XYZ vertex position displacements of type `[f32; 3]`.
     #[serde(rename = "POSITION")]

--- a/gltf-json/src/root.rs
+++ b/gltf-json/src/root.rs
@@ -56,7 +56,7 @@ impl<T> Index<T> {
 }
 
 /// The root object of a glTF 2.0 asset.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 #[gltf(validate_hook = "root_validate_hook")]
 pub struct Root {
     /// An array of accessors.

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -13,7 +13,7 @@ use serde_derive::{Deserialize, Serialize};
 /// identity. When a node is targeted for animation (referenced by an
 /// animation.channel.target), only TRS properties may be present; `matrix` will not
 /// be present.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Node {
     /// The index of the camera referenced by this node.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,7 +79,7 @@ pub struct Node {
 }
 
 /// The root `Node`s of a scene.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Scene {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -102,7 +102,7 @@ pub struct Scene {
 }
 
 /// Unit quaternion rotation in the order (x, y, z, w), where w is the scalar.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub struct UnitQuaternion(pub [f32; 4]);
 
 impl Default for UnitQuaternion {

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -3,7 +3,7 @@ use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 
 /// Joints and matrices defining a skin.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 pub struct Skin {
     /// Extension specific data.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -130,7 +130,7 @@ impl WrappingMode {
 }
 
 /// Texture sampler properties for filtering and wrapping modes.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Validate, PartialEq)]
 #[serde(default)]
 pub struct Sampler {
     /// Magnification filter.
@@ -192,7 +192,7 @@ where
 }
 
 /// A texture and its sampler.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Texture {
     /// Optional user-defined name for this object.
     #[cfg(feature = "names")]
@@ -259,7 +259,7 @@ impl Validate for Texture {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+#[derive(Clone, Debug, Deserialize, Serialize, Validate, PartialEq)]
 /// Reference to a `Texture`.
 pub struct Info {
     /// The index of the texture.


### PR DESCRIPTION
I am trying to use this library to serialize meshes for my project into the gltf format. In order to confirm I'm doing it correctly, I would like to compare a mesh gltf imported from a working exporter, and the mesh gltf exported from the one I'm working on.

However, I cannot compare gltf files as `Root` does not currently implement `PartialEq`

This pr resolves this by implementing PartialEq on `Root` and all attributes that `Root` uses.