### PR TITLE
examples/export: Replace unsound `to_padded_byte_vector()` implementation with `bytemuck`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = ["gltf-derive", "gltf-json"]
 
 [dev-dependencies]
 approx = "0.5"
+bytemuck = { version = "1.21.0", features = ["derive"] }
 
 [dependencies]
 base64 = { optional = true, version = "0.13" }


### PR DESCRIPTION
The function `to_padded_byte_vector()` is unsound because:

* It accepts an arbitrary `Vec<T>` without checking that `T` contains no padding, which is UB to read in any way including by reinterpreting as `u8`s.
* It produces a `Vec` which thinks it has a different alignment than the allocation was actually created with.

To fix these problems, this change:

* Uses `bytemuck` to check the no-padding condition.
* Creates a new `Vec` instead of trying to reuse the existing one. (Conditional reuse would be possible, but more complex.)

An alternative to using `bytemuck` would be to make `to_padded_byte_vector()` an `unsafe fn` (or to accept `Vertex` only instead of `T`). However, I think it is valuable to demonstrate how to do this conversion using safe tools, to encourage people to use safe code instead of writing unsafe code without fully understanding the requirements.