### PR TITLE
Add `no_std` Support to `gltf` and `gltf-json`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,19 @@ jobs:
 
       - name: Semantic versioning checks
         uses: obi1kenobi/cargo-semver-checks-action@v2
+  
+  check-compiles-no-std:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - "x86_64-unknown-none"
+          - "wasm32v1-none"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Check Compile
+        run: cargo check --no-default-features --features spin,allow_empty_animation_target_node,allow_empty_texture,extensions,extras,names,utils,KHR_lights_punctual,KHR_materials_pbrSpecularGlossiness,KHR_materials_unlit,KHR_texture_transform,KHR_materials_transmission,KHR_materials_ior,KHR_materials_variants,KHR_materials_volume,KHR_materials_specular,KHR_materials_emissive_strength,guess_mime_type,libm --target ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The top-level `gltf` crate adheres to [Semantic Versioning](http://semver.org/sp
 ### Added
 
 - New feature flag `allow_empty_animation_target_node` to be able to parse newer animated assets.
+- Added new feature flags for `std`, `spin`, and `libm`, which are used for `no_std` support.
 
 ## [1.4.1] - 2024-05-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,13 @@ approx = "0.5"
 bytemuck = { version = "1.21.0", features = ["derive"] }
 
 [dependencies]
+gltf-json = { path = "gltf-json", version = "=1.4.1", default-features = false }
+byteorder = { version = "1.3", default-features = false }
+lazy_static = { version = "1", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["raw_value"] }
 base64 = { optional = true, version = "0.13" }
-byteorder = "1.3"
-gltf-json = { path = "gltf-json", version = "=1.4.1" }
-lazy_static = "1"
 urlencoding = { optional = true, version = "2.1" }
-serde_json = { features = ["raw_value"], version = "1.0" }
+libm = { version = "0.2", optional = true }
 
 [dependencies.image]
 default-features = false
@@ -38,14 +39,14 @@ optional = true
 version = "0.25"
 
 [features]
-default = ["import", "utils", "names"]
+default = ["std", "import", "utils", "names"]
 allow_empty_animation_target_node = ["gltf-json/allow_empty_animation_target_node"]
 allow_empty_texture = ["gltf-json/allow_empty_texture"]
 extensions = ["gltf-json/extensions"]
 extras = ["gltf-json/extras"]
 names = ["gltf-json/names"]
 utils = []
-import = ["base64", "image", "urlencoding"]
+import = ["base64", "image", "urlencoding", "std"]
 KHR_lights_punctual = ["gltf-json/KHR_lights_punctual"]
 KHR_materials_pbrSpecularGlossiness = ["gltf-json/KHR_materials_pbrSpecularGlossiness"]
 KHR_materials_unlit = ["gltf-json/KHR_materials_unlit"]
@@ -56,8 +57,11 @@ KHR_materials_variants = ["gltf-json/KHR_materials_variants"]
 KHR_materials_volume = ["gltf-json/KHR_materials_volume"]
 KHR_materials_specular = ["gltf-json/KHR_materials_specular"]
 KHR_materials_emissive_strength = ["gltf-json/KHR_materials_emissive_strength"]
-EXT_texture_webp = ["gltf-json/EXT_texture_webp", "image/webp"]
+EXT_texture_webp = ["gltf-json/EXT_texture_webp", "image/webp", "std"]
 guess_mime_type = []
+std = ["gltf-json/std", "serde_json/std", "byteorder/std"]
+spin = ["lazy_static/spin_no_std"]
+libm = ["dep:libm"]
 
 [[example]]
 name = "gltf-display"

--- a/gltf-json/Cargo.toml
+++ b/gltf-json/Cargo.toml
@@ -10,12 +10,12 @@ rust-version = "1.61"
 
 [dependencies]
 gltf-derive = { path = "../gltf-derive", version = "=1.4.1" }
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = { features = ["raw_value"], version = "1.0" }
+serde = { version = "1.0", default-features = false }
+serde_derive = { version = "1.0", default-features = false }
+serde_json = { version = "1.0", default-features = false, features = ["alloc", "raw_value"] }
 
 [features]
-default = []
+default = ["std"]
 allow_empty_animation_target_node = []
 allow_empty_texture = []
 names = []
@@ -32,3 +32,4 @@ KHR_materials_volume = []
 KHR_texture_transform = []
 KHR_materials_emissive_strength = []
 EXT_texture_webp = []
+std = ["serde_json/std"]

--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -1,10 +1,13 @@
 use crate::validation::{Checked, Error, USize64};
 use crate::{buffer, extensions, Extras, Index, Path, Root};
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
-use std::fmt;
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// The component data type.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]

--- a/gltf-json/src/animation.rs
+++ b/gltf-json/src/animation.rs
@@ -1,9 +1,13 @@
 use crate::validation::{Checked, Error, Validate};
 use crate::{accessor, extensions, scene, Extras, Index, Path, Root};
+use alloc::vec::Vec;
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// All valid animation interpolation algorithms.
 pub const VALID_INTERPOLATIONS: &[&str] = &["LINEAR", "STEP", "CUBICSPLINE"];

--- a/gltf-json/src/asset.rs
+++ b/gltf-json/src/asset.rs
@@ -1,4 +1,5 @@
 use crate::{extensions, Extras};
+use alloc::string::{String, ToString};
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 

--- a/gltf-json/src/buffer.rs
+++ b/gltf-json/src/buffer.rs
@@ -1,9 +1,10 @@
 use crate::validation::{Checked, Error, USize64, Validate};
 use crate::{extensions, Extras, Index, Path, Root};
+use alloc::string::String;
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
 
 /// Corresponds to `GL_ARRAY_BUFFER`.
 pub const ARRAY_BUFFER: u32 = 34_962;

--- a/gltf-json/src/camera.rs
+++ b/gltf-json/src/camera.rs
@@ -1,9 +1,12 @@
 use crate::validation::{Checked, Error};
 use crate::{extensions, Extras, Path, Root};
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// All valid camera types.
 pub const VALID_CAMERA_TYPES: &[&str] = &["perspective", "orthographic"];

--- a/gltf-json/src/extensions/accessor.rs
+++ b/gltf-json/src/extensions/accessor.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// Contains data structures for sparse storage.
 pub mod sparse {
     use super::*;

--- a/gltf-json/src/extensions/animation.rs
+++ b/gltf-json/src/extensions/animation.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// A keyframe animation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Animation {

--- a/gltf-json/src/extensions/buffer.rs
+++ b/gltf-json/src/extensions/buffer.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// A buffer points to binary data representing geometry, animations, or skins.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Buffer {

--- a/gltf-json/src/extensions/camera.rs
+++ b/gltf-json/src/extensions/camera.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// A camera's projection.
 ///
 /// A node can reference a camera to apply a transform to place the camera in the

--- a/gltf-json/src/extensions/image.rs
+++ b/gltf-json/src/extensions/image.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// Image data used to create a texture.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Image {

--- a/gltf-json/src/extensions/material.rs
+++ b/gltf-json/src/extensions/material.rs
@@ -5,6 +5,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// The material appearance of a primitive.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Material {

--- a/gltf-json/src/extensions/mesh.rs
+++ b/gltf-json/src/extensions/mesh.rs
@@ -3,6 +3,12 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "KHR_materials_variants")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// A set of primitives to be rendered.
 ///
 /// A node can contain one or more meshes and its transform places the meshes in

--- a/gltf-json/src/extensions/root.rs
+++ b/gltf-json/src/extensions/root.rs
@@ -3,6 +3,12 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "KHR_materials_variants")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// The root object of a glTF 2.0 asset.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Root {

--- a/gltf-json/src/extensions/scene.rs
+++ b/gltf-json/src/extensions/scene.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// A node in the node hierarchy.  When the node contains `skin`, all
 /// `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.
 /// A node can have either a `matrix` or any combination of
@@ -32,10 +35,11 @@ pub struct Node {
 pub mod khr_lights_punctual {
     use crate::validation::{Checked, Error};
     use crate::{Extras, Index, Path, Root};
+    use alloc::string::String;
+    use core::fmt;
     use gltf_derive::Validate;
     use serde::{de, ser};
     use serde_derive::{Deserialize, Serialize};
-    use std::fmt;
 
     /// All valid light types.
     pub const VALID_TYPES: &[&str] = &["directional", "point", "spot"];
@@ -85,7 +89,7 @@ pub mod khr_lights_punctual {
 
         /// Extension specific data.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        pub extensions: Option<std::boxed::Box<serde_json::value::RawValue>>,
+        pub extensions: Option<alloc::boxed::Box<serde_json::value::RawValue>>,
 
         /// Optional application specific data.
         #[serde(default)]
@@ -151,7 +155,7 @@ pub mod khr_lights_punctual {
     }
 
     fn outer_cone_angle_default() -> f32 {
-        std::f32::consts::FRAC_PI_4
+        core::f32::consts::FRAC_PI_4
     }
 
     impl<'de> de::Deserialize<'de> for Checked<Type> {
@@ -203,6 +207,7 @@ pub mod khr_lights_punctual {
 pub mod khr_materials_variants {
     use crate::validation::{Error, Validate};
     use crate::{Path, Root};
+    use alloc::string::String;
     use serde_derive::{Deserialize, Serialize};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/gltf-json/src/extensions/skin.rs
+++ b/gltf-json/src/extensions/skin.rs
@@ -3,6 +3,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "extensions")]
+use alloc::string::String;
+
 /// Joints and matrices defining a skin.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Skin {

--- a/gltf-json/src/extensions/texture.rs
+++ b/gltf-json/src/extensions/texture.rs
@@ -8,6 +8,9 @@ use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "extensions")]
 use serde_json::{Map, Value};
 
+#[cfg(feature = "names")]
+use alloc::string::String;
+
 /// Texture sampler properties for filtering and wrapping modes.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Validate)]
 pub struct Sampler {

--- a/gltf-json/src/extras.rs
+++ b/gltf-json/src/extras.rs
@@ -1,13 +1,13 @@
+use core::fmt;
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
 
 #[cfg(feature = "extras")]
 pub use serde_json::value::RawValue;
 
 /// Data type of the `extras` attribute on all glTF objects.
 #[cfg(feature = "extras")]
-pub type Extras = Option<::std::boxed::Box<RawValue>>;
+pub type Extras = Option<::alloc::boxed::Box<RawValue>>;
 
 /// Data type of the `extras` attribute on all glTF objects.
 #[cfg(not(feature = "extras"))]

--- a/gltf-json/src/image.rs
+++ b/gltf-json/src/image.rs
@@ -1,5 +1,6 @@
 use crate::validation::Validate;
 use crate::{buffer, extensions, Extras, Index};
+use alloc::string::String;
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
 

--- a/gltf-json/src/lib.rs
+++ b/gltf-json/src/lib.rs
@@ -1,3 +1,10 @@
+#![no_std]
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
+extern crate alloc;
+
 /// Contains `Accessor` and other related data structures.
 pub mod accessor;
 
@@ -92,7 +99,10 @@ pub use serde_json::Value;
 /// so that one can deserialize data structures other than `Root` without
 /// being bound to a specific version of `serde_json`.
 pub mod deserialize {
-    pub use serde_json::{from_reader, from_slice, from_str, from_value};
+    pub use serde_json::{from_slice, from_str, from_value};
+
+    #[cfg(feature = "std")]
+    pub use serde_json::from_reader;
 }
 
 /// Re-exports of `serde_json` serialization functions.
@@ -101,7 +111,8 @@ pub mod deserialize {
 /// so that one can serialize data structures other than `Root` without
 /// being bound to a specific version of `serde_json`.
 pub mod serialize {
-    pub use serde_json::{
-        to_string, to_string_pretty, to_value, to_vec, to_vec_pretty, to_writer, to_writer_pretty,
-    };
+    pub use serde_json::{to_string, to_string_pretty, to_value, to_vec, to_vec_pretty};
+
+    #[cfg(feature = "std")]
+    pub use serde_json::{to_writer, to_writer_pretty};
 }

--- a/gltf-json/src/material.rs
+++ b/gltf-json/src/material.rs
@@ -1,9 +1,12 @@
 use crate::validation::{Checked, Validate};
 use crate::{extensions, texture, Extras, Index};
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// All valid alpha modes.
 pub const VALID_ALPHA_MODES: &[&str] = &["OPAQUE", "MASK", "BLEND"];

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -1,11 +1,16 @@
 use crate::validation::{Checked, Error};
 use crate::{accessor, extensions, material, Extras, Index};
+use alloc::{
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::from_value;
-use std::collections::BTreeMap;
-use std::fmt;
 
 /// Corresponds to `GL_POINTS`.
 pub const POINTS: u32 = 0;

--- a/gltf-json/src/path.rs
+++ b/gltf-json/src/path.rs
@@ -1,4 +1,8 @@
-use std::fmt;
+use alloc::{
+    format,
+    string::{String, ToString},
+};
+use core::fmt;
 
 /// An immutable JSON source path.
 #[derive(Default, Clone, Debug, PartialEq)]

--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -1,7 +1,11 @@
 use crate::validation::Validate;
 use crate::{camera, extensions, mesh, scene, skin, Extras, Index};
+use alloc::vec::Vec;
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// A node in the node hierarchy.  When the node contains `skin`, all
 /// `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.

--- a/gltf-json/src/skin.rs
+++ b/gltf-json/src/skin.rs
@@ -1,6 +1,10 @@
 use crate::{accessor, extensions, scene, Extras, Index};
+use alloc::vec::Vec;
 use gltf_derive::Validate;
 use serde_derive::{Deserialize, Serialize};
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// Joints and matrices defining a skin.
 #[derive(Clone, Debug, Deserialize, Serialize, Validate)]

--- a/gltf-json/src/texture.rs
+++ b/gltf-json/src/texture.rs
@@ -1,9 +1,12 @@
 use crate::validation::{Checked, Validate};
 use crate::{extensions, image, Extras, Index};
+use core::fmt;
 use gltf_derive::Validate;
 use serde::{de, ser};
 use serde_derive::{Deserialize, Serialize};
-use std::fmt;
+
+#[cfg(feature = "names")]
+use alloc::string::String;
 
 /// Corresponds to `GL_NEAREST`.
 pub const NEAREST: u32 = 9728;

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -1,7 +1,7 @@
 use alloc::{
+    collections::BTreeMap,
     string::{String, ToString},
     vec::Vec,
-    collections::BTreeMap,
 };
 use core::hash::Hash;
 use serde::{ser, Serialize, Serializer};

--- a/gltf-json/src/validation.rs
+++ b/gltf-json/src/validation.rs
@@ -1,6 +1,10 @@
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+    collections::BTreeMap,
+};
+use core::hash::Hash;
 use serde::{ser, Serialize, Serializer};
-use std::collections::BTreeMap;
-use std::hash::Hash;
 
 use crate::{Path, Root};
 
@@ -197,7 +201,7 @@ impl<T: Validate> Validate for Vec<T> {
     }
 }
 
-impl Validate for std::boxed::Box<serde_json::value::RawValue> {
+impl Validate for alloc::boxed::Box<serde_json::value::RawValue> {
     fn validate<P, R>(&self, _: &Root, _: P, _: &mut R)
     where
         P: Fn() -> Path,
@@ -207,10 +211,14 @@ impl Validate for std::boxed::Box<serde_json::value::RawValue> {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+#[cfg(not(feature = "std"))]
+impl core::error::Error for Error {}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(
             f,
             "{}",

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -61,7 +61,10 @@ use crate::{buffer, Document};
 pub use json::accessor::ComponentType as DataType;
 pub use json::accessor::Type as Dimensions;
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// Utility functions.
 #[cfg(feature = "utils")]

--- a/src/accessor/util.rs
+++ b/src/accessor/util.rs
@@ -1,6 +1,5 @@
 use byteorder::{ByteOrder, LE};
-use std::marker::PhantomData;
-use std::{iter, mem};
+use core::{iter, marker::PhantomData, mem};
 
 use crate::{accessor, buffer};
 

--- a/src/animation/iter.rs
+++ b/src/animation/iter.rs
@@ -1,4 +1,4 @@
-use std::{iter, slice};
+use core::{iter, slice};
 
 use crate::animation::{Animation, Channel, Sampler};
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -5,7 +5,10 @@ use crate::Buffer;
 
 pub use json::animation::{Interpolation, Property};
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// Iterators.
 pub mod iter;

--- a/src/animation/util/morph_target_weights.rs
+++ b/src/animation/util/morph_target_weights.rs
@@ -1,6 +1,6 @@
 use super::MorphTargetWeights;
 use crate::Normalize;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Casting iterator for `MorphTargetWeights`.
 #[derive(Clone, Debug)]

--- a/src/animation/util/rotations.rs
+++ b/src/animation/util/rotations.rs
@@ -1,6 +1,6 @@
 use super::Rotations;
 use crate::Normalize;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Casting iterator for `Rotations`.
 #[derive(Clone, Debug)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,11 +1,14 @@
 #[cfg(feature = "import")]
-use std::ops;
+use {alloc::vec::Vec, core::ops};
 
 use crate::Document;
 
 pub use json::buffer::Target;
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// A buffer points to binary data representing geometry, animations, or skins.
 #[derive(Clone, Debug)]

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,7 +1,10 @@
 use crate::Document;
 
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// A camera's projection.
 #[derive(Clone, Debug)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,10 +2,17 @@
 use crate::{buffer, Document, Error, Result};
 
 #[cfg(feature = "import")]
+use alloc::vec::Vec;
+
+#[cfg(feature = "import")]
 #[cfg_attr(docsrs, doc(cfg(feature = "import")))]
 use image_crate::DynamicImage;
+
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// Format of image pixel data.
 #[cfg(feature = "import")]

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,13 +1,12 @@
 use crate::buffer;
 use crate::image;
-use std::borrow::Cow;
-use std::{fs, io};
+use alloc::{borrow::Cow, vec::Vec};
+use std::{fs, io, path::Path};
 
 use crate::{Document, Error, Gltf, Result};
 #[cfg(feature = "EXT_texture_webp")]
 use image_crate::ImageFormat::WebP;
 use image_crate::ImageFormat::{Jpeg, Png};
-use std::path::Path;
 
 /// Return type of `import`.
 type Import = (Document, Vec<buffer::Data>, Vec<image::Data>);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,5 @@
-use std::{iter, slice};
+use alloc::string::String;
+use core::{iter, slice};
 
 use crate::accessor::Accessor;
 use crate::animation::Animation;

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,8 +1,12 @@
 use crate::{texture, Document};
 
 pub use json::material::AlphaMode;
+
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 lazy_static! {
     static ref DEFAULT_MATERIAL: json::material::Material = Default::default();

--- a/src/mesh/iter.rs
+++ b/src/mesh/iter.rs
@@ -1,4 +1,5 @@
-use std::{collections, iter, slice};
+use alloc::collections;
+use core::{iter, slice};
 
 use super::{Attribute, Mesh, MorphTarget, Primitive};
 use crate::Document;

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -63,8 +63,12 @@ use crate::accessor;
 
 pub use json::mesh::{Mode, Semantic};
 use json::validation::Checked;
+
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 /// Vertex attribute data.
 pub type Attribute<'a> = (Semantic, Accessor<'a>);

--- a/src/mesh/util/colors.rs
+++ b/src/mesh/util/colors.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::Normalize;
 

--- a/src/mesh/util/indices.rs
+++ b/src/mesh/util/indices.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::ReadIndices;
 

--- a/src/mesh/util/joints.rs
+++ b/src/mesh/util/joints.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::ReadJoints;
 

--- a/src/mesh/util/tex_coords.rs
+++ b/src/mesh/util/tex_coords.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::Normalize;
 

--- a/src/mesh/util/weights.rs
+++ b/src/mesh/util/weights.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::Normalize;
 

--- a/src/scene/iter.rs
+++ b/src/scene/iter.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use core::slice;
 
 use crate::{Document, Node};
 

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 use crate::math::*;
 use crate::{Camera, Document, Mesh, Skin};
@@ -54,6 +57,7 @@ impl Transform {
     ///
     /// If the transform is `Matrix`, then the decomposition is extracted from the
     /// matrix.
+    #[cfg(any(feature = "std", feature = "libm"))]
     pub fn decomposed(self) -> ([f32; 3], [f32; 4], [f32; 3]) {
         match self {
             Transform::Matrix { matrix: m } => {
@@ -285,7 +289,7 @@ impl<'a> Scene<'a> {
 mod tests {
     use crate::math::*;
     use crate::scene::Transform;
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     fn rotate(x: f32, y: f32, z: f32, r: f32) -> [f32; 4] {
         let r = Quaternion::from_axis_angle(Vector3::new(x, y, z).normalize(), r);

--- a/src/skin/iter.rs
+++ b/src/skin/iter.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use core::slice;
 
 use crate::{Document, Node};
 

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 use crate::{Accessor, Document, Node};
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,8 +1,12 @@
 use crate::{image, Document};
 
 pub use json::texture::{MagFilter, MinFilter, WrappingMode};
+
 #[cfg(feature = "extensions")]
-use serde_json::{Map, Value};
+use {
+    alloc::string::String,
+    serde_json::{Map, Value},
+};
 
 lazy_static! {
     static ref DEFAULT_SAMPLER: json::texture::Sampler = Default::default();


### PR DESCRIPTION
# Objective

Adding `no_std` support is generally desirable across the Rust ecosystem, allowing more users to consume and contribute to the project.

## Solution

- Added `std` feature to `gltf-json` and `gltf` (enabled by default). Note that when disabled the MSRV increases.
- Added `spin`, and `libm` features to `gltf` for compatibility on `no_std` targets.
- Added a CI task to catch regressions in `no_std` support. Note that since Cargo has no syntax for "all features _except_ ...", this must list all features except those which explicitly require `std`.

---

## Notes

- I'm mainly a contributor to the Bevy game engine, where I have been progressively adding `no_std` support. Adding such support to `gltf` would be desirable but is not immediately required.
- This is my first time contributing to this project. Please let me know if there's anything I can do to assist with this PR!