### PR TITLE
Add `unvalidated_data` feature flag for APIs that don't assume pre-validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ KHR_materials_sheen = ["gltf-json/KHR_materials_sheen"]
 KHR_materials_clearcoat = ["gltf-json/KHR_materials_clearcoat"]
 KHR_materials_emissive_strength = ["gltf-json/KHR_materials_emissive_strength"]
 EXT_texture_webp = ["gltf-json/EXT_texture_webp", "image/webp"]
+unvalidated_data = []
 guess_mime_type = []
 
 [[example]]

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -197,4 +197,20 @@ impl<'a> Accessor<'a> {
             .as_ref()
             .map(|json| sparse::Sparse::new(self.document, json))
     }
+
+    /// Identical to `Accessor::view` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_view(&self) -> Option<Result<buffer::View<'a>, json::validation::Error>> {
+        let view = self.json.buffer_view.as_ref()?;
+        Some(
+            self.document
+                .0
+                .buffer_views
+                .get(view.value())
+                .ok_or(json::validation::Error::IndexOutOfBounds)
+                .map(|json| buffer::View::new(self.document, view.value(), json)),
+        )
+    }
 }

--- a/src/accessor/sparse.rs
+++ b/src/accessor/sparse.rs
@@ -55,6 +55,13 @@ impl<'a> Indices<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Indices::view` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_view(&self) -> Result<buffer::View<'a>, json::validation::Error> {
+        self.document.nth_view(self.json.buffer_view.value())
+    }
 }
 
 /// Sparse storage of attributes that deviate from their initialization value.
@@ -127,6 +134,13 @@ impl<'a> Values<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Identical to `Values::view` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_view(&self) -> Result<buffer::View<'a>, json::validation::Error> {
+        self.document.nth_view(self.json.buffer_view.value())
     }
 }
 

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -134,6 +134,17 @@ impl<'a> Animation<'a> {
         let ext = self.json.extensions.as_ref()?;
         ext.others.get(ext_name)
     }
+
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    fn nth_sampler(&self, index: usize) -> Result<Sampler<'a>, json::validation::Error> {
+        let json = self
+            .json
+            .samplers
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Sampler::new(self.clone(), json, index))
+    }
 }
 
 impl<'a> Channel<'a> {
@@ -184,6 +195,14 @@ impl<'a> Channel<'a> {
     pub fn index(&self) -> usize {
         self.index
     }
+
+    /// Identical to `Channel::sampler` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_sampler(&self) -> Result<Sampler<'a>, json::validation::Error> {
+        self.anim.nth_sampler(self.json.sampler.value())
+    }
 }
 
 impl<'a> Target<'a> {
@@ -215,6 +234,14 @@ impl<'a> Target<'a> {
     /// targets it instantiates.
     pub fn property(&self) -> Property {
         self.json.path.unwrap()
+    }
+
+    /// Identical to `Target::node` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_node(&self) -> Result<scene::Node<'a>, json::validation::Error> {
+        self.anim.document.nth_node(self.json.node.value())
     }
 }
 
@@ -264,5 +291,21 @@ impl<'a> Sampler<'a> {
             .accessors()
             .nth(self.json.output.value())
             .unwrap()
+    }
+
+    /// Identical to `Sampler::input` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_input(&self) -> Result<accessor::Accessor<'a>, json::validation::Error> {
+        self.anim.document.nth_accessor(self.json.input.value())
+    }
+
+    /// Identical to `Sampler::output` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_output(&self) -> Result<accessor::Accessor<'a>, json::validation::Error> {
+        self.anim.document.nth_accessor(self.json.output.value())
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -206,4 +206,29 @@ impl<'a> View<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Tries to construct a view with an unvalidated index.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_new(
+        document: &'a Document,
+        index: usize,
+        json: &'a json::buffer::View,
+    ) -> Result<Self, json::validation::Error> {
+        let parent = document.nth_buffer(index)?;
+
+        Ok(Self {
+            document,
+            index,
+            json,
+            parent,
+        })
+    }
+
+    /// Identical to `View::buffer` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_buffer(&self) -> Result<Buffer<'a>, json::validation::Error> {
+        self.document.nth_buffer(self.json.buffer.value())
+    }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -151,6 +151,21 @@ impl<'a> Image<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Image::source` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_source(&self) -> Result<Source<'a>, json::validation::Error> {
+        if let Some(index) = self.json.buffer_view.as_ref() {
+            let view = self.document.nth_view(index.value())?;
+            let mime_type = self.json.mime_type.as_ref().map(|x| x.0.as_str()).unwrap();
+            Ok(Source::View { view, mime_type })
+        } else {
+            let uri = self.json.uri.as_ref().unwrap();
+            let mime_type = self.json.mime_type.as_ref().map(|x| x.0.as_str());
+            Ok(Source::Uri { uri, mime_type })
+        }
+    }
 }
 
 #[cfg(feature = "import")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(missing_docs)]
 #![allow(unknown_lints)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -190,7 +189,7 @@ pub(crate) trait Normalize<T> {
 }
 
 /// Result type for convenience.
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T, E = Error> = result::Result<T, E>;
 
 /// Represents a runtime error.
 #[derive(Debug)]
@@ -570,6 +569,168 @@ impl Document {
             iter: self.0.buffer_views.iter().enumerate(),
             document: self,
         }
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_accessor(
+        &self,
+        index: usize,
+    ) -> Result<Accessor<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .accessors
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Accessor::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_buffer(&self, index: usize) -> Result<Buffer<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .buffers
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Buffer::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_camera(&self, index: usize) -> Result<Camera<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .cameras
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Camera::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_image(&self, index: usize) -> Result<Image<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .images
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Image::new(self, index, json))
+    }
+
+    #[cfg(all(feature = "KHR_lights_punctual", feature = "unvalidated_data"))]
+    pub(crate) fn nth_light(
+        &self,
+        index: usize,
+    ) -> Option<Result<khr_lights_punctual::Light<'_>, json::validation::Error>> {
+        use json::extensions;
+
+        self.0
+            .extensions
+            .as_ref()
+            .and_then(|extensions| extensions.khr_lights_punctual.as_ref())
+            .map(|khr_lights_punctual| {
+                let json = khr_lights_punctual
+                    .lights
+                    .get(index)
+                    .ok_or(json::validation::Error::IndexOutOfBounds)?;
+
+                Ok(khr_lights_punctual::Light::new(self, index, json))
+            })
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_material(
+        &self,
+        index: usize,
+    ) -> Result<Material<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .materials
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Material::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_mesh(&self, index: usize) -> Result<Mesh<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .meshes
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Mesh::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_node(&self, index: usize) -> Result<Node<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .nodes
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Node::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_sampler(
+        &self,
+        index: usize,
+    ) -> Result<texture::Sampler<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .samplers
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(texture::Sampler::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_scene(&self, index: usize) -> Result<Scene<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .scenes
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Scene::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_skin(&self, index: usize) -> Result<Skin<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .skins
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Skin::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_texture(&self, index: usize) -> Result<Texture<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .textures
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(Texture::new(self, index, json))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    pub(crate) fn nth_view(
+        &self,
+        index: usize,
+    ) -> Result<buffer::View<'_>, json::validation::Error> {
+        let json = self
+            .0
+            .buffer_views
+            .get(index)
+            .ok_or(json::validation::Error::IndexOutOfBounds)?;
+        Ok(buffer::View::new(self, index, json))
+    }
+
+    /// Identical to `Document::default_scene` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_default_scene(&self) -> Option<Result<Scene<'_>, json::validation::Error>> {
+        let index = self.0.scene.as_ref()?;
+        Some(self.nth_scene(index.value()))
     }
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -277,6 +277,43 @@ impl<'a> Material<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Material::normal_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_normal_texture(&self) -> Option<Result<NormalTexture<'a>, json::validation::Error>> {
+        self.json.normal_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(NormalTexture::new(texture, json))
+        })
+    }
+
+    /// Identical to `Material::occlusion_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_occlusion_texture(
+        &self,
+    ) -> Option<Result<OcclusionTexture<'a>, json::validation::Error>> {
+        self.json.occlusion_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(OcclusionTexture::new(texture, json))
+        })
+    }
+
+    /// Identical to `Material::emissive_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_emissive_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.emissive_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
 }
 
 /// A set of parameter values that are used to define the metallic-roughness
@@ -364,6 +401,32 @@ impl<'a> PbrMetallicRoughness<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `PbrMetallicRoughness::base_color_texture` other than returning an error in
+    /// the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_base_color_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.base_color_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `PbrMetallicRoughness::metallic_roughness_texture` other than returning an
+    /// error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_metallic_roughness_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.metallic_roughness_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
 }
 
 /// A set of parameter values that are used to define the transmissions
@@ -407,6 +470,19 @@ impl<'a> Transmission<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Identical to `Transmission::transmission_texture` other than returning an error in the
+    /// case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_transmission_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.transmission_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
     }
 }
 
@@ -467,6 +543,19 @@ impl<'a> Volume<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Volume::thickness_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_thickness_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.thickness_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
 }
 
 /// Parameter values that define the strength and colour of the specular reflection of the material
@@ -524,6 +613,32 @@ impl<'a> Specular<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Identical to `Specular::specular_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_specular_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.specular_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `Specular::specular_color_texture` other than returning an error in the
+    /// case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_specular_color_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.specular_color_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
     }
 }
 
@@ -598,6 +713,32 @@ impl<'a> PbrSpecularGlossiness<'a> {
     /// Optional application specific data.
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
+    }
+
+    /// Identical to `PbrSpecularGlossiness::diffuse_texture` other than returning an error in
+    /// the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_diffuse_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.diffuse_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `PbrSpecularGlossiness::specular_glossiness_texture` other than returning
+    /// an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_specular_glossiness_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.specular_glossiness_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
     }
 }
 
@@ -813,6 +954,45 @@ impl<'a> Clearcoat<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Clearcoat::clearcoat_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_clearcoat_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.clearcoat_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `Clearcoat::clearcoat_roughness_texture` other than returning an error in
+    /// the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_clearcoat_roughness_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.clearcoat_roughness_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `Clearcoat::clearcoat_normal_texture` other than returning an error in the
+    /// case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_clearcoat_normal_texture(
+        &self,
+    ) -> Option<Result<NormalTexture<'_>, json::validation::Error>> {
+        self.json.clearcoat_normal_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(NormalTexture::new(texture, json))
+        })
+    }
 }
 
 /// Parameter values that define the clearcoat material model.
@@ -870,4 +1050,33 @@ impl<'a> Sheen<'a> {
     pub fn extras(&self) -> &'a json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Sheen::sheen_color_texture` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_sheen_color_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.sheen_color_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
+
+    /// Identical to `Sheen::sheen_roughness_texture` other than returning an error in the case
+    /// of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_sheen_roughness_texture(
+        &self,
+    ) -> Option<Result<texture::Info<'a>, json::validation::Error>> {
+        self.json.sheen_roughness_texture.as_ref().map(|json| {
+            let texture = self.document.nth_texture(json.index.value())?;
+            Ok(texture::Info::new(texture, json))
+        })
+    }
 }
+
+#[cfg(all(test, feature = "unvalidated_data"))]
+mod try_tests;

--- a/src/material/try_tests.rs
+++ b/src/material/try_tests.rs
@@ -1,0 +1,116 @@
+use crate::{json::Root, Document, Error, Material};
+
+fn as_validation_err(err: &Error) -> Option<&[(json::Path, json::validation::Error)]> {
+    match err {
+        Error::Validation(errors) => Some(errors),
+        _ => None,
+    }
+}
+
+fn validation_errors(
+    err: Option<&Error>,
+) -> impl Iterator<Item = json::validation::Error> + use<'_> {
+    err.and_then(as_validation_err)
+        .into_iter()
+        .flat_map(|errs| errs.iter().map(|(_, e)| e).copied())
+}
+
+fn expect_parse_err(raw_json: &str) -> Document {
+    let root = Root::from_str(raw_json).unwrap();
+
+    let parse_error = Document::from_json(root.clone()).err();
+    let validation_errs = validation_errors(parse_error.as_ref());
+
+    let expected = std::iter::once(json::validation::Error::IndexOutOfBounds);
+
+    assert!(
+        validation_errs.eq(expected),
+        "should contain exactly one validation index out of bounds error: {parse_error:?} "
+    );
+
+    Document::from_json_without_validation(root)
+}
+
+fn assert_access_err<'a, T>(
+    document: &'a Document,
+    access: impl Fn(Material<'a>) -> Option<Result<T, json::validation::Error>>,
+) where
+    T: 'a,
+{
+    let material = document.nth_material(0).unwrap();
+    let actual_err = access(material).map(Result::err).flatten();
+
+    assert_eq!(actual_err, Some(json::validation::Error::IndexOutOfBounds));
+}
+
+#[test]
+fn try_base_color_texture() {
+    let raw = r#"
+        {
+            "materials" : [
+                {
+                    "pbrMetallicRoughness": {
+                        "baseColorTexture": {
+                            "index": 0
+                        }
+                    }
+                }
+            ],
+            "asset": {
+                "version": "2.0"
+            }
+        }"#;
+
+    let document = expect_parse_err(raw);
+
+    assert_access_err(&document, |m| {
+        m.pbr_metallic_roughness().try_base_color_texture()
+    });
+}
+
+#[test]
+fn try_emissive_texture() {
+    let raw = r#"
+        {
+            "materials" : [
+                {
+                    "emissiveTexture": {
+                        "index": 0
+                    }
+                }
+            ],
+            "asset": {
+                "version": "2.0"
+            }
+        }"#;
+
+    let document = expect_parse_err(raw);
+
+    assert_access_err(&document, |m| m.try_emissive_texture());
+}
+
+#[cfg(feature = "KHR_materials_specular")]
+#[test]
+fn try_specular_texture() {
+    let raw = r#"
+        {
+            "materials" : [
+                {
+                    "extensions": {
+                        "KHR_materials_specular": {
+                            "specularTexture": {
+                                "index": 0
+                            }
+                        }
+                    }
+                }
+            ],
+            "asset": {
+                "version": "2.0"
+            }
+        }"#;
+
+    let document = expect_parse_err(raw);
+
+    assert_access_err(&document, |m| m.specular().unwrap().try_specular_texture());
+}

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -325,6 +325,61 @@ impl<'a> Primitive<'a> {
             get_buffer_data,
         }
     }
+
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_bounding_box(&self) -> Result<BoundingBox, json::validation::Error> {
+        let pos_accessor_index = self
+            .json
+            .attributes
+            .get(&Checked::Valid(Semantic::Positions))
+            .ok_or(json::validation::Error::Missing)?;
+        let pos_accessor = self
+            .mesh
+            .document
+            .nth_accessor(pos_accessor_index.value())?;
+
+        let min_value = pos_accessor.min().ok_or(json::validation::Error::Missing)?;
+        let max_value = pos_accessor.max().ok_or(json::validation::Error::Missing)?;
+
+        let min: [f32; 3] = json::deserialize::from_value(min_value)
+            .map_err(|_| json::validation::Error::Invalid)?;
+        let max: [f32; 3] = json::deserialize::from_value(max_value)
+            .map_err(|_| json::validation::Error::Invalid)?;
+        Ok(Bounds { min, max })
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_get(
+        &self,
+        semantic: &Semantic,
+    ) -> Option<Result<Accessor<'a>, json::validation::Error>> {
+        let index = self
+            .json
+            .attributes
+            .get(&json::validation::Checked::Valid(semantic.clone()))?;
+        Some(self.mesh.document.nth_accessor(index.value()))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_indices(&self) -> Option<Result<Accessor<'a>, json::validation::Error>> {
+        self.json
+            .indices
+            .as_ref()
+            .map(|index| self.mesh.document.nth_accessor(index.value()))
+    }
+
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_material(&self) -> Result<Material<'a>, json::validation::Error> {
+        self.json
+            .material
+            .as_ref()
+            .map(|index| self.mesh.document.nth_material(index.value()))
+            .unwrap_or_else(|| Ok(Material::default(self.mesh.document)))
+    }
 }
 
 #[cfg(feature = "utils")]

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -228,6 +228,56 @@ impl<'a> Node<'a> {
     pub fn weights(&self) -> Option<&'a [f32]> {
         self.json.weights.as_deref()
     }
+
+    /// Identical to `Node::camera` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_camera(&self) -> Option<Result<Camera<'a>, json::validation::Error>> {
+        self.json
+            .camera
+            .as_ref()
+            .map(|index| self.document.nth_camera(index.value()))
+    }
+
+    #[cfg(all(feature = "KHR_lights_punctual", feature = "unvalidated_data"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "KHR_lights_punctual", feature = "unvalidated_data")))
+    )]
+    pub fn try_light(
+        &self,
+    ) -> Option<Result<crate::khr_lights_punctual::Light<'a>, json::validation::Error>> {
+        if let Some(extensions) = self.json.extensions.as_ref() {
+            if let Some(khr_lights_punctual) = extensions.khr_lights_punctual.as_ref() {
+                self.document.nth_light(khr_lights_punctual.light.value())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Identical to `Node::mesh` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_mesh(&self) -> Option<Result<Mesh<'a>, json::validation::Error>> {
+        self.json
+            .mesh
+            .as_ref()
+            .map(|index| self.document.nth_mesh(index.value()))
+    }
+
+    /// Identical to `Node::skin` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_skin(&self) -> Option<Result<Skin<'a>, json::validation::Error>> {
+        self.json
+            .skin
+            .as_ref()
+            .map(|index| self.document.nth_skin(index.value()))
+    }
 }
 
 impl<'a> Scene<'a> {

--- a/src/skin/mod.rs
+++ b/src/skin/mod.rs
@@ -115,4 +115,27 @@ impl<'a> Skin<'a> {
             .as_ref()
             .map(|index| self.document.nodes().nth(index.value()).unwrap())
     }
+
+    /// Identical to `Skin::inverse_bind_matrices` other than returning an error in the case of
+    /// invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_inverse_bind_matrices(
+        &self,
+    ) -> Option<Result<Accessor<'a>, json::validation::Error>> {
+        self.json
+            .inverse_bind_matrices
+            .as_ref()
+            .map(|index| self.document.nth_accessor(index.value()))
+    }
+
+    /// Identical to `Skin::skeleton` other than returning an error in the case of invalid data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_skeleton(&self) -> Option<Result<Node<'a>, json::validation::Error>> {
+        self.json
+            .skeleton
+            .as_ref()
+            .map(|index| self.document.nth_node(index.value()))
+    }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -193,6 +193,26 @@ impl<'a> Texture<'a> {
     pub fn extras(&self) -> &json::Extras {
         &self.json.extras
     }
+
+    /// Identical to `Texture::sampler` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_sampler(&self) -> Result<Sampler<'a>, json::validation::Error> {
+        self.json
+            .sampler
+            .as_ref()
+            .map(|index| self.document.nth_sampler(index.value()))
+            .unwrap_or_else(|| Ok(Sampler::default(self.document)))
+    }
+
+    /// Identical to `Texture::source` other than returning an error in the case of invalid
+    /// data.
+    #[cfg(feature = "unvalidated_data")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unvalidated_data")))]
+    pub fn try_source(&self) -> Result<image::Image<'a>, json::validation::Error> {
+        self.document.nth_image(self.json.primary_source().value())
+    }
 }
 
 impl<'a> Info<'a> {


### PR DESCRIPTION
Hello! As described in https://github.com/gltf-rs/gltf/issues/460, my team has a need for APIs that will not panic in the case of invalid data. Based on the discussion in that issue, my impression is that the main concern is whether adding APIs like this might mislead users into thinking that this is the "default" way to interact with this crate rather than a potentially niche use-case. My instinct is that this could potentially be handled by putting the fallible APIs behind a feature flag that's named in a way that would stick out to a casual user, like "unvalidated-data", so I wanted to make a PR proposing this in order to get feedback on whether you think this might be a viable path forward.

These changes are by no means comprehensive in trying to provide alternatives to all possible parts of the API that currently panic, but they cover everything we happen to need for our use-case. In particular, I didn't make any attempt to provide an alternative to the the iterator APIs, as it seemed like it would require a bit more effort to figure out what an idiomatic non-panicking version of them would look like.

I erred on the side of modifying as little of the existing code as possible to avoid any chance of regressions. (When implementing it, I did briefly investigate whether it would make sense to update the existing APIs to unwrap the fallible versions of the methods to avoid duplication, but it ended up being a bit tricky to avoid needing to add separate versions of the new methods to mark them as `pub(crate)` when the feature isn't specified for internal use and `pub` when the feature is present due to there not currently being anything like `cfg_attr` for visibility keywords). To that end, the only change to existing code I made was updating the `Result` type alias to use the crate's error type as a default that could be overridden rather than hard-coded, which allowed using `Result<T, json::validation::Error>` on the new methods without needing to prefix with `std::result::`. This is a minor ergonomic feature though, so I'd be happy to remove if it for some reason it's not desirable.

To ensure that the methods worked as intended, I made sure to define new tests for each of them that assert that attempting errors returned by operating on the unvalidated data returns an error that matches up with what's returned when attempting to validate the JSON up-front.

If for some reason merging these changes doesn't make sense, I totally understand, and in the short-term we're comfortable using our own fork with the changes we need. I thought it might be worthwhile to share a PoC of what I think might be a way to provide what we need while maintaining consistency with your vision for how the crate's API should be used rather than place the burden on you to spend effort trying to understand what we're looking for and coming up with a way to satisfy it. At the very least, the MR might provide some ideas for any other users who end up having similar needs to us at some point in the future.