### PR TITLE
Allow missing nodes field in scenes

### DIFF
--- a/gltf-json/src/scene.rs
+++ b/gltf-json/src/scene.rs
@@ -97,7 +97,7 @@ pub struct Scene {
     pub name: Option<String>,
 
     /// The indices of each root node.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub nodes: Vec<Index<Node>>,
 }
 


### PR DESCRIPTION
It's a tiny fix for #349 

As per the [GLTF spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#nodes-and-hierarchy) 
>glTF assets MAY define nodes

Serialization already omits the `nodes` field if the list is empty and deserialization shouldn't throw an error for a missing `nodes` field either.