### PR TITLE
Add morphed TEXCOORD_n/COLOR_n support to morph targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The top-level `gltf` crate adheres to [Semantic Versioning](http://semver.org/sp
 
 ### Added
 
+- Support morphed `TEXCOORD_<n>` and `COLOR_<n>` attributes in morph target
+  dictionaries, per the glTF 2.0 specification. `gltf::mesh::MorphTarget` now
+  exposes `tex_coords(set)`, `colors(set)`, `tex_coords_sets()` and
+  `colors_sets()`, and `gltf::mesh::Reader` gains `read_morph_target_tex_coords`
+  and `read_morph_target_colors` for reading per-set displacement streams.
+  Closes #432.
 - Support for the `KHR_animation_pointer` extension.
 
 ### Added

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -1,7 +1,7 @@
 use crate::validation::{Checked, Error};
 use crate::{accessor, extensions, material, Extras, Index};
 use gltf_derive::Validate;
-use serde::{de, ser};
+use serde::{de, ser, Serialize};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::from_value;
 use std::collections::BTreeMap;
@@ -39,8 +39,12 @@ pub const VALID_MODES: &[u32] = &[
     TRIANGLE_FAN,
 ];
 
-/// All valid semantic names for Morph targets.
-pub const VALID_MORPH_TARGETS: &[&str] = &["POSITION", "NORMAL", "TANGENT"];
+/// All valid base semantic names for Morph targets.
+///
+/// Per the glTF 2.0 specification, a morph target dictionary may contain
+/// `POSITION`, `NORMAL`, `TANGENT`, plus numbered `TEXCOORD_<n>` and
+/// `COLOR_<n>` attribute deviations.
+pub const VALID_MORPH_TARGETS: &[&str] = &["POSITION", "NORMAL", "TANGENT", "TEXCOORD", "COLOR"];
 
 /// The type of primitives to render.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
@@ -126,9 +130,9 @@ pub struct Primitive {
     #[serde(default, skip_serializing_if = "is_primitive_mode_default")]
     pub mode: Checked<Mode>,
 
-    /// An array of Morph Targets, each  Morph Target is a dictionary mapping
-    /// attributes (only `POSITION`, `NORMAL`, and `TANGENT` supported) to their
-    /// deviations in the Morph Target.
+    /// An array of Morph Targets, each Morph Target is a dictionary mapping
+    /// attributes (`POSITION`, `NORMAL`, `TANGENT`, and numbered `TEXCOORD_<n>`
+    /// / `COLOR_<n>` attributes) to their deviations in the Morph Target.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub targets: Option<Vec<MorphTarget>>,
 }
@@ -179,22 +183,139 @@ where
 }
 
 /// A dictionary mapping attributes to their deviations in the Morph Target.
-#[derive(Clone, Debug, Deserialize, Serialize, Validate)]
+///
+/// Per the glTF 2.0 specification, a morph target dictionary may contain the
+/// fixed attributes `POSITION`, `NORMAL` and `TANGENT`, plus numbered
+/// `TEXCOORD_<n>` and `COLOR_<n>` attribute deviations. The numbered
+/// attributes are stored in [`MorphTarget::tex_coords`] and
+/// [`MorphTarget::colors`] as maps keyed by the set index `n`.
+#[derive(Clone, Debug, Validate)]
 pub struct MorphTarget {
     /// XYZ vertex position displacements of type `[f32; 3]`.
-    #[serde(rename = "POSITION")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub positions: Option<Index<accessor::Accessor>>,
 
     /// XYZ vertex normal displacements of type `[f32; 3]`.
-    #[serde(rename = "NORMAL")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub normals: Option<Index<accessor::Accessor>>,
 
     /// XYZ vertex tangent displacements of type `[f32; 3]`.
-    #[serde(rename = "TANGENT")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tangents: Option<Index<accessor::Accessor>>,
+
+    /// UV texture co-ordinate displacements, keyed by `TEXCOORD_<n>` set index.
+    pub tex_coords: BTreeMap<u32, Index<accessor::Accessor>>,
+
+    /// Vertex color displacements, keyed by `COLOR_<n>` set index.
+    pub colors: BTreeMap<u32, Index<accessor::Accessor>>,
+}
+
+impl Serialize for MorphTarget {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        use ser::SerializeMap;
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(ref p) = self.positions {
+            map.serialize_entry("POSITION", p)?;
+        }
+        if let Some(ref n) = self.normals {
+            map.serialize_entry("NORMAL", n)?;
+        }
+        if let Some(ref t) = self.tangents {
+            map.serialize_entry("TANGENT", t)?;
+        }
+        for (set, index) in &self.tex_coords {
+            map.serialize_entry(&format!("TEXCOORD_{}", set), index)?;
+        }
+        for (set, index) in &self.colors {
+            map.serialize_entry(&format!("COLOR_{}", set), index)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> de::Deserialize<'de> for MorphTarget {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct MorphTargetVisitor;
+
+        impl<'de> de::Visitor<'de> for MorphTargetVisitor {
+            type Value = MorphTarget;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "a morph target attribute dictionary")
+            }
+
+            fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut positions = None;
+                let mut normals = None;
+                let mut tangents = None;
+                let mut tex_coords: BTreeMap<u32, Index<accessor::Accessor>> = BTreeMap::new();
+                let mut colors: BTreeMap<u32, Index<accessor::Accessor>> = BTreeMap::new();
+                while let Some(key) = access.next_key::<String>()? {
+                    match key.as_str() {
+                        "POSITION" => {
+                            positions = Some(access.next_value()?);
+                        }
+                        "NORMAL" => {
+                            normals = Some(access.next_value()?);
+                        }
+                        "TANGENT" => {
+                            tangents = Some(access.next_value()?);
+                        }
+                        other => {
+                            if let Some(rest) = other.strip_prefix("TEXCOORD_") {
+                                match rest.parse::<u32>() {
+                                    Ok(set) => {
+                                        let index = access.next_value()?;
+                                        tex_coords.insert(set, index);
+                                    }
+                                    Err(_) => {
+                                        return Err(de::Error::custom(format!(
+                                            "invalid TEXCOORD set index: {}",
+                                            other
+                                        )))
+                                    }
+                                }
+                            } else if let Some(rest) = other.strip_prefix("COLOR_") {
+                                match rest.parse::<u32>() {
+                                    Ok(set) => {
+                                        let index = access.next_value()?;
+                                        colors.insert(set, index);
+                                    }
+                                    Err(_) => {
+                                        return Err(de::Error::custom(format!(
+                                            "invalid COLOR set index: {}",
+                                            other
+                                        )))
+                                    }
+                                }
+                            } else {
+                                // Unknown key: skip its value so the
+                                // deserializer stays forward-compatible with
+                                // new fixed attributes added by future spec
+                                // revisions.
+                                let _: de::IgnoredAny = access.next_value()?;
+                            }
+                        }
+                    }
+                }
+                Ok(MorphTarget {
+                    positions,
+                    normals,
+                    tangents,
+                    tex_coords,
+                    colors,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(MorphTargetVisitor)
+    }
 }
 
 /// Vertex attribute semantic name.

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -209,6 +209,18 @@ pub struct MorphTarget {
     pub colors: BTreeMap<u32, Index<accessor::Accessor>>,
 }
 
+impl Default for MorphTarget {
+    fn default() -> Self {
+        MorphTarget {
+            positions: None,
+            normals: None,
+            tangents: None,
+            tex_coords: BTreeMap::new(),
+            colors: BTreeMap::new(),
+        }
+    }
+}
+
 impl Serialize for MorphTarget {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/gltf-json/src/mesh.rs
+++ b/gltf-json/src/mesh.rs
@@ -200,10 +200,12 @@ pub struct MorphTarget {
     /// XYZ vertex tangent displacements of type `[f32; 3]`.
     pub tangents: Option<Index<accessor::Accessor>>,
 
-    /// UV texture co-ordinate displacements, keyed by `TEXCOORD_<n>` set index.
+    /// UV texture co-ordinate displacements of type `[f32; 2]`, keyed by
+    /// `TEXCOORD_<n>` set index.
     pub tex_coords: BTreeMap<u32, Index<accessor::Accessor>>,
 
-    /// Vertex color displacements, keyed by `COLOR_<n>` set index.
+    /// Vertex color displacements of type `[f32; 3]` or `[f32; 4]` (RGB or
+    /// RGBA), keyed by `COLOR_<n>` set index.
     pub colors: BTreeMap<u32, Index<accessor::Accessor>>,
 }
 

--- a/src/mesh/iter.rs
+++ b/src/mesh/iter.rs
@@ -100,10 +100,22 @@ fn map_morph_target<'a>(
         .tangents
         .as_ref()
         .map(|index| document.accessors().nth(index.value()).unwrap());
+    let tex_coords = json
+        .tex_coords
+        .iter()
+        .map(|(set, index)| (*set, document.accessors().nth(index.value()).unwrap()))
+        .collect();
+    let colors = json
+        .colors
+        .iter()
+        .map(|(set, index)| (*set, document.accessors().nth(index.value()).unwrap()))
+        .collect();
     MorphTarget {
         positions,
         normals,
         tangents,
+        tex_coords,
+        colors,
     }
 }
 

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -459,7 +459,7 @@ where
     /// Visits the morph targets of the primitive.
     pub fn read_morph_targets(&self) -> util::ReadMorphTargets<'a, 's, F> {
         util::ReadMorphTargets {
-            index: 0,
+            iter: self.primitive.morph_targets(),
             reader: self.clone(),
         }
     }
@@ -475,7 +475,7 @@ where
         set: u32,
     ) -> util::ReadMorphTargetTexCoords<'a, 's, F> {
         util::ReadMorphTargetTexCoords {
-            index: 0,
+            iter: self.primitive.morph_targets(),
             set,
             reader: self.clone(),
         }
@@ -489,7 +489,7 @@ where
     /// that morph target does not define the requested `COLOR_<n>` set.
     pub fn read_morph_target_colors(&self, set: u32) -> util::ReadMorphTargetColors<'a, 's, F> {
         util::ReadMorphTargetColors {
-            index: 0,
+            iter: self.primitive.morph_targets(),
             set,
             reader: self.clone(),
         }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -57,6 +57,7 @@ pub mod iter;
 pub mod util;
 
 use crate::{Accessor, Buffer, Document, Material};
+use std::collections;
 
 #[cfg(feature = "utils")]
 use crate::accessor;
@@ -106,6 +107,12 @@ pub struct MorphTarget<'a> {
 
     /// XYZ vertex tangent displacements.
     tangents: Option<Accessor<'a>>,
+
+    /// UV texture co-ordinate displacements, keyed by `TEXCOORD_<n>` set index.
+    tex_coords: collections::BTreeMap<u32, Accessor<'a>>,
+
+    /// Vertex color displacements, keyed by `COLOR_<n>` set index.
+    colors: collections::BTreeMap<u32, Accessor<'a>>,
 }
 
 /// Geometry to be rendered with the given material.
@@ -456,6 +463,37 @@ where
             reader: self.clone(),
         }
     }
+
+    /// Visits the `TEXCOORD_<n>` displacements of the morph targets of the
+    /// primitive for the given set index.
+    ///
+    /// Yields one `Option<util::ReadTexCoords>` per morph target, in the same
+    /// order the morph targets appear in the primitive. The item is `None` if
+    /// that morph target does not define the requested `TEXCOORD_<n>` set.
+    pub fn read_morph_target_tex_coords(
+        &self,
+        set: u32,
+    ) -> util::ReadMorphTargetTexCoords<'a, 's, F> {
+        util::ReadMorphTargetTexCoords {
+            index: 0,
+            set,
+            reader: self.clone(),
+        }
+    }
+
+    /// Visits the `COLOR_<n>` displacements of the morph targets of the
+    /// primitive for the given set index.
+    ///
+    /// Yields one `Option<util::ReadColors>` per morph target, in the same
+    /// order the morph targets appear in the primitive. The item is `None` if
+    /// that morph target does not define the requested `COLOR_<n>` set.
+    pub fn read_morph_target_colors(&self, set: u32) -> util::ReadMorphTargetColors<'a, 's, F> {
+        util::ReadMorphTargetColors {
+            index: 0,
+            set,
+            reader: self.clone(),
+        }
+    }
 }
 
 impl<'a> MorphTarget<'a> {
@@ -472,5 +510,29 @@ impl<'a> MorphTarget<'a> {
     /// Returns the XYZ vertex tangent displacements.
     pub fn tangents(&self) -> Option<Accessor<'a>> {
         self.tangents.clone()
+    }
+
+    /// Returns the `TEXCOORD_<n>` displacement accessor for the given set, if
+    /// present in this morph target.
+    pub fn tex_coords(&self, set: u32) -> Option<Accessor<'a>> {
+        self.tex_coords.get(&set).cloned()
+    }
+
+    /// Returns the `COLOR_<n>` displacement accessor for the given set, if
+    /// present in this morph target.
+    pub fn colors(&self, set: u32) -> Option<Accessor<'a>> {
+        self.colors.get(&set).cloned()
+    }
+
+    /// Returns an iterator over the `TEXCOORD_<n>` set indices present in this
+    /// morph target.
+    pub fn tex_coords_sets(&self) -> impl Iterator<Item = u32> + '_ {
+        self.tex_coords.keys().copied()
+    }
+
+    /// Returns an iterator over the `COLOR_<n>` set indices present in this
+    /// morph target.
+    pub fn colors_sets(&self) -> impl Iterator<Item = u32> + '_ {
+        self.colors.keys().copied()
     }
 }

--- a/src/mesh/util/mod.rs
+++ b/src/mesh/util/mod.rs
@@ -15,7 +15,7 @@ pub mod weights;
 
 use crate::mesh;
 
-use crate::accessor::Iter;
+use crate::accessor::{self, Iter};
 use crate::Buffer;
 
 /// XYZ vertex positions of type `[f32; 3]`.
@@ -141,6 +141,119 @@ where
                     .tangents()
                     .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
                 (positions, normals, tangents)
+            })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.reader.primitive.morph_targets().size_hint()
+    }
+}
+
+/// UV texture co-ordinate displacements for a single `TEXCOORD_<n>` set across
+/// all morph targets of a primitive.
+///
+/// Produced by [`mesh::Reader::read_morph_target_tex_coords`]. Yields one
+/// `Option<ReadTexCoords>` per morph target, in the same order the morph
+/// targets appear in the primitive.
+#[derive(Clone, Debug)]
+pub struct ReadMorphTargetTexCoords<'a, 's, F>
+where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
+{
+    pub(crate) index: usize,
+    pub(crate) set: u32,
+    pub(crate) reader: mesh::Reader<'a, 's, F>,
+}
+
+impl<'a, 's, F> ExactSizeIterator for ReadMorphTargetTexCoords<'a, 's, F> where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>
+{
+}
+
+impl<'a, 's, F> Iterator for ReadMorphTargetTexCoords<'a, 's, F>
+where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
+{
+    type Item = Option<ReadTexCoords<'s>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        use accessor::DataType;
+        self.index += 1;
+        self.reader
+            .primitive
+            .morph_targets()
+            .nth(self.index - 1)
+            .map(|morph_target| {
+                morph_target
+                    .tex_coords(self.set)
+                    .and_then(|accessor| match accessor.data_type() {
+                        DataType::U8 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadTexCoords::U8),
+                        DataType::U16 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadTexCoords::U16),
+                        DataType::F32 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadTexCoords::F32),
+                        _ => unreachable!(),
+                    })
+            })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.reader.primitive.morph_targets().size_hint()
+    }
+}
+
+/// Vertex color displacements for a single `COLOR_<n>` set across all morph
+/// targets of a primitive.
+///
+/// Produced by [`mesh::Reader::read_morph_target_colors`]. Yields one
+/// `Option<ReadColors>` per morph target, in the same order the morph targets
+/// appear in the primitive.
+#[derive(Clone, Debug)]
+pub struct ReadMorphTargetColors<'a, 's, F>
+where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
+{
+    pub(crate) index: usize,
+    pub(crate) set: u32,
+    pub(crate) reader: mesh::Reader<'a, 's, F>,
+}
+
+impl<'a, 's, F> ExactSizeIterator for ReadMorphTargetColors<'a, 's, F> where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>
+{
+}
+
+impl<'a, 's, F> Iterator for ReadMorphTargetColors<'a, 's, F>
+where
+    F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
+{
+    type Item = Option<ReadColors<'s>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        use accessor::DataType::{F32, U16, U8};
+        use accessor::Dimensions::{Vec3, Vec4};
+        self.index += 1;
+        self.reader
+            .primitive
+            .morph_targets()
+            .nth(self.index - 1)
+            .map(|morph_target| {
+                morph_target.colors(self.set).and_then(|accessor| {
+                    match (accessor.data_type(), accessor.dimensions()) {
+                        (U8, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbU8),
+                        (U16, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbU16),
+                        (F32, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbF32),
+                        (U8, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbaU8),
+                        (U16, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbaU16),
+                        (F32, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                            .map(ReadColors::RgbaF32),
+                        _ => unreachable!(),
+                    }
+                })
             })
     }
 

--- a/src/mesh/util/mod.rs
+++ b/src/mesh/util/mod.rs
@@ -106,7 +106,7 @@ pub struct ReadMorphTargets<'a, 's, F>
 where
     F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
 {
-    pub(crate) index: usize,
+    pub(crate) iter: mesh::iter::MorphTargets<'a>,
     pub(crate) reader: mesh::Reader<'a, 's, F>,
 }
 
@@ -125,27 +125,22 @@ where
         Option<ReadTangentDisplacements<'s>>,
     );
     fn next(&mut self) -> Option<Self::Item> {
-        self.index += 1;
-        self.reader
-            .primitive
-            .morph_targets()
-            .nth(self.index - 1)
-            .map(|morph_target| {
-                let positions = morph_target
-                    .positions()
-                    .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
-                let normals = morph_target
-                    .normals()
-                    .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
-                let tangents = morph_target
-                    .tangents()
-                    .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
-                (positions, normals, tangents)
-            })
+        self.iter.next().map(|morph_target| {
+            let positions = morph_target
+                .positions()
+                .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
+            let normals = morph_target
+                .normals()
+                .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
+            let tangents = morph_target
+                .tangents()
+                .and_then(|accessor| Iter::new(accessor, self.reader.get_buffer_data.clone()));
+            (positions, normals, tangents)
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.reader.primitive.morph_targets().size_hint()
+        self.iter.size_hint()
     }
 }
 
@@ -160,7 +155,7 @@ pub struct ReadMorphTargetTexCoords<'a, 's, F>
 where
     F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
 {
-    pub(crate) index: usize,
+    pub(crate) iter: mesh::iter::MorphTargets<'a>,
     pub(crate) set: u32,
     pub(crate) reader: mesh::Reader<'a, 's, F>,
 }
@@ -177,28 +172,23 @@ where
     type Item = Option<ReadTexCoords<'s>>;
     fn next(&mut self) -> Option<Self::Item> {
         use accessor::DataType;
-        self.index += 1;
-        self.reader
-            .primitive
-            .morph_targets()
-            .nth(self.index - 1)
-            .map(|morph_target| {
-                morph_target
-                    .tex_coords(self.set)
-                    .and_then(|accessor| match accessor.data_type() {
-                        DataType::U8 => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadTexCoords::U8),
-                        DataType::U16 => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadTexCoords::U16),
-                        DataType::F32 => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadTexCoords::F32),
-                        _ => unreachable!(),
-                    })
-            })
+        self.iter.next().map(|morph_target| {
+            morph_target
+                .tex_coords(self.set)
+                .and_then(|accessor| match accessor.data_type() {
+                    DataType::U8 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadTexCoords::U8),
+                    DataType::U16 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadTexCoords::U16),
+                    DataType::F32 => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadTexCoords::F32),
+                    _ => unreachable!(),
+                })
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.reader.primitive.morph_targets().size_hint()
+        self.iter.size_hint()
     }
 }
 
@@ -213,7 +203,7 @@ pub struct ReadMorphTargetColors<'a, 's, F>
 where
     F: Clone + Fn(Buffer<'a>) -> Option<&'s [u8]>,
 {
-    pub(crate) index: usize,
+    pub(crate) iter: mesh::iter::MorphTargets<'a>,
     pub(crate) set: u32,
     pub(crate) reader: mesh::Reader<'a, 's, F>,
 }
@@ -231,34 +221,29 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         use accessor::DataType::{F32, U16, U8};
         use accessor::Dimensions::{Vec3, Vec4};
-        self.index += 1;
-        self.reader
-            .primitive
-            .morph_targets()
-            .nth(self.index - 1)
-            .map(|morph_target| {
-                morph_target.colors(self.set).and_then(|accessor| {
-                    match (accessor.data_type(), accessor.dimensions()) {
-                        (U8, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbU8),
-                        (U16, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbU16),
-                        (F32, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbF32),
-                        (U8, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbaU8),
-                        (U16, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbaU16),
-                        (F32, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
-                            .map(ReadColors::RgbaF32),
-                        _ => unreachable!(),
-                    }
-                })
+        self.iter.next().map(|morph_target| {
+            morph_target.colors(self.set).and_then(|accessor| {
+                match (accessor.data_type(), accessor.dimensions()) {
+                    (U8, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbU8),
+                    (U16, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbU16),
+                    (F32, Vec3) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbF32),
+                    (U8, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbaU8),
+                    (U16, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbaU16),
+                    (F32, Vec4) => Iter::new(accessor, self.reader.get_buffer_data.clone())
+                        .map(ReadColors::RgbaF32),
+                    _ => unreachable!(),
+                }
             })
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.reader.primitive.morph_targets().size_hint()
+        self.iter.size_hint()
     }
 }
 

--- a/tests/morphed_texcoord_color.gltf
+++ b/tests/morphed_texcoord_color.gltf
@@ -19,14 +19,18 @@
           "attributes": {
             "POSITION": 1,
             "TEXCOORD_0": 2,
-            "COLOR_0": 3
+            "TEXCOORD_1": 3,
+            "COLOR_0": 4,
+            "COLOR_1": 5
           },
           "indices": 0,
           "targets": [
             {
-              "POSITION": 4,
-              "TEXCOORD_0": 5,
-              "COLOR_0": 6
+              "POSITION": 6,
+              "TEXCOORD_0": 7,
+              "TEXCOORD_1": 8,
+              "COLOR_0": 9,
+              "COLOR_1": 10
             }
           ]
         }
@@ -35,8 +39,8 @@
   ],
   "buffers": [
     {
-      "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD/NzMw9zczMPc3MzD3NzEw+AAAAAAAAAAAAAAAAzcxMPgAAAADNzEw9zcxMPc3MzD0AAAAAAAAAAM3MzD3NzMw9AAAAAAAAAAAAAAAAzczMPQAAAAAAAAAAAAAAAM3MzD0=",
-      "byteLength": 200
+      "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAIA+AACAPgAAQD8AAIA+AACAPgAAQD8AAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAA/AAAAPwAAAD8AAIA+AACAPgAAgD4AAEA/AABAPwAAQD/NzMw9zczMPc3MzD3NzEw+AAAAAAAAAAAAAAAAzcxMPgAAAADNzEw9zcxMPc3MzD0AAAAAAAAAAM3MzD0K16M8CtejPI/C9TwAAAAAAAAAAI/C9TzNzMw9AAAAAAAAAAAAAAAAzczMPQAAAAAAAAAAAAAAAM3MzD0K16M8AAAAAAAAAAAAAAAACtejPAAAAAAAAAAAAAAAAArXozw=",
+      "byteLength": 320
     }
   ],
   "bufferViews": [
@@ -61,22 +65,44 @@
     {
       "buffer": 0,
       "byteOffset": 68,
+      "byteLength": 24,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 92,
       "byteLength": 36,
       "target": 34962
     },
     {
       "buffer": 0,
-      "byteOffset": 104,
-      "byteLength": 36
-    },
-    {
-      "buffer": 0,
-      "byteOffset": 140,
-      "byteLength": 24
+      "byteOffset": 128,
+      "byteLength": 36,
+      "target": 34962
     },
     {
       "buffer": 0,
       "byteOffset": 164,
+      "byteLength": 36
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 200,
+      "byteLength": 24
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 224,
+      "byteLength": 24
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 248,
+      "byteLength": 36
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 284,
       "byteLength": 36
     }
   ],
@@ -105,7 +131,7 @@
       "bufferView": 3,
       "componentType": 5126,
       "count": 3,
-      "type": "VEC3"
+      "type": "VEC2"
     },
     {
       "bufferView": 4,
@@ -117,10 +143,34 @@
       "bufferView": 5,
       "componentType": 5126,
       "count": 3,
-      "type": "VEC2"
+      "type": "VEC3"
     },
     {
       "bufferView": 6,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 7,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 8,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 9,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 10,
       "componentType": 5126,
       "count": 3,
       "type": "VEC3"

--- a/tests/morphed_texcoord_color.gltf
+++ b/tests/morphed_texcoord_color.gltf
@@ -1,0 +1,129 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "scenes": [
+    {
+      "nodes": [0]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 1,
+            "TEXCOORD_0": 2,
+            "COLOR_0": 3
+          },
+          "indices": 0,
+          "targets": [
+            {
+              "POSITION": 4,
+              "TEXCOORD_0": 5,
+              "COLOR_0": 6
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAABAAIAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD/NzMw9zczMPc3MzD3NzEw+AAAAAAAAAAAAAAAAzcxMPgAAAADNzEw9zcxMPc3MzD0AAAAAAAAAAM3MzD3NzMw9AAAAAAAAAAAAAAAAzczMPQAAAAAAAAAAAAAAAM3MzD0=",
+      "byteLength": 200
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 6,
+      "target": 34963
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 8,
+      "byteLength": 36,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 44,
+      "byteLength": 24,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 68,
+      "byteLength": 36,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 104,
+      "byteLength": 36
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 140,
+      "byteLength": 24
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 164,
+      "byteLength": 36
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [1.0, 1.0, 0.0],
+      "min": [0.0, 0.0, 0.0]
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 5,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 6,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3"
+    }
+  ]
+}

--- a/tests/test_wrapper.rs
+++ b/tests/test_wrapper.rs
@@ -128,8 +128,9 @@ fn test_sparse_accessor_without_base_buffer_view_yield_all_values() {
 }
 
 /// `morphed_texcoord_color.gltf` contains a single primitive with one morph
-/// target that defines `POSITION`, `TEXCOORD_0` and `COLOR_0` displacements,
-/// exercising the morphed attribute support added for gltf-rs/gltf#432.
+/// target that defines `POSITION`, `TEXCOORD_0`/`TEXCOORD_1` and
+/// `COLOR_0`/`COLOR_1` displacements, exercising the numbered morphed attribute
+/// support added for gltf-rs/gltf#432.
 const MORPHED_TEXCOORD_COLOR_GLTF: &str = "tests/morphed_texcoord_color.gltf";
 
 #[test]
@@ -146,18 +147,21 @@ fn test_morph_target_tex_coords_and_colors() {
 
     // POSITION displacement is present.
     assert!(morph_target.positions().is_some());
-    // TEXCOORD_0 displacement is present and accessible via the set accessor.
+    // Both TEXCOORD_0 and TEXCOORD_1 displacements are present and accessible
+    // via the per-set accessor; a set that isn't defined yields None.
     assert!(morph_target.tex_coords(0).is_some());
-    assert!(morph_target.tex_coords(1).is_none());
-    // COLOR_0 displacement is present and accessible via the set accessor.
+    assert!(morph_target.tex_coords(1).is_some());
+    assert!(morph_target.tex_coords(2).is_none());
+    // Both COLOR_0 and COLOR_1 displacements are present.
     assert!(morph_target.colors(0).is_some());
-    assert!(morph_target.colors(1).is_none());
+    assert!(morph_target.colors(1).is_some());
+    assert!(morph_target.colors(2).is_none());
 
-    // Set-index iterators report the expected sets.
+    // Set-index iterators report the expected sets, ordered by set index.
     let tex_coords_sets: Vec<u32> = morph_target.tex_coords_sets().collect();
-    assert_eq!(tex_coords_sets, [0]);
+    assert_eq!(tex_coords_sets, [0, 1]);
     let colors_sets: Vec<u32> = morph_target.colors_sets().collect();
-    assert_eq!(colors_sets, [0]);
+    assert_eq!(colors_sets, [0, 1]);
 
     let reader = primitive
         .reader(|buffer: gltf::Buffer| buffers.get(buffer.index()).map(|data| &data.0[..]));
@@ -188,6 +192,22 @@ fn test_morph_target_tex_coords_and_colors() {
         assert!(mt_tex_coords.next().is_none());
     }
 
+    // read_morph_target_tex_coords(1) returns the *distinct* set-1 deltas,
+    // proving the reader dispatches by set index and not just set 0.
+    {
+        let mut mt_tex_coords = reader.read_morph_target_tex_coords(1);
+        let tex_coords_opt = mt_tex_coords.next().unwrap();
+        assert!(tex_coords_opt.is_some(), "TEXCOORD_1 displacement expected");
+        let tex_coords = tex_coords_opt.unwrap();
+        let uv: Vec<[f32; 2]> = tex_coords.into_f32().collect();
+        assert_eq!(
+            uv,
+            [[0.02, 0.02], [0.03, 0.0], [0.0, 0.03]],
+            "morph target TEXCOORD_1 displacements"
+        );
+        assert!(mt_tex_coords.next().is_none());
+    }
+
     // Requesting a set that doesn't exist on any morph target still iterates
     // once (one morph target), yielding None for that morph target.
     {
@@ -198,15 +218,32 @@ fn test_morph_target_tex_coords_and_colors() {
 
     // read_morph_target_colors(0) yields one item, which is
     // Some(ReadColors::RgbF32(..)) for this asset.
-    let mut mt_colors = reader.read_morph_target_colors(0);
-    let colors_opt = mt_colors.next().unwrap();
-    assert!(colors_opt.is_some(), "COLOR_0 displacement expected");
-    let colors = colors_opt.unwrap();
-    let rgb: Vec<[f32; 3]> = colors.into_rgb_f32().collect();
-    assert_eq!(
-        rgb,
-        [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 0.1]],
-        "morph target COLOR_0 displacements"
-    );
-    assert!(mt_colors.next().is_none());
+    {
+        let mut mt_colors = reader.read_morph_target_colors(0);
+        let colors_opt = mt_colors.next().unwrap();
+        assert!(colors_opt.is_some(), "COLOR_0 displacement expected");
+        let colors = colors_opt.unwrap();
+        let rgb: Vec<[f32; 3]> = colors.into_rgb_f32().collect();
+        assert_eq!(
+            rgb,
+            [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 0.1]],
+            "morph target COLOR_0 displacements"
+        );
+        assert!(mt_colors.next().is_none());
+    }
+
+    // read_morph_target_colors(1) returns the distinct set-1 color deltas.
+    {
+        let mut mt_colors = reader.read_morph_target_colors(1);
+        let colors_opt = mt_colors.next().unwrap();
+        assert!(colors_opt.is_some(), "COLOR_1 displacement expected");
+        let colors = colors_opt.unwrap();
+        let rgb: Vec<[f32; 3]> = colors.into_rgb_f32().collect();
+        assert_eq!(
+            rgb,
+            [[0.02, 0.0, 0.0], [0.0, 0.02, 0.0], [0.0, 0.0, 0.02]],
+            "morph target COLOR_1 displacements"
+        );
+        assert!(mt_colors.next().is_none());
+    }
 }

--- a/tests/test_wrapper.rs
+++ b/tests/test_wrapper.rs
@@ -126,3 +126,87 @@ fn test_sparse_accessor_without_base_buffer_view_yield_all_values() {
         assert_eq!(o - EXPECTED_OUTPUTS[i], 0.0);
     }
 }
+
+/// `morphed_texcoord_color.gltf` contains a single primitive with one morph
+/// target that defines `POSITION`, `TEXCOORD_0` and `COLOR_0` displacements,
+/// exercising the morphed attribute support added for gltf-rs/gltf#432.
+const MORPHED_TEXCOORD_COLOR_GLTF: &str = "tests/morphed_texcoord_color.gltf";
+
+#[test]
+fn test_morph_target_tex_coords_and_colors() {
+    let (document, buffers, _) = gltf::import(MORPHED_TEXCOORD_COLOR_GLTF).unwrap();
+
+    let mesh = document.meshes().next().unwrap();
+    let primitive = mesh.primitives().next().unwrap();
+
+    // The primitive exposes a single morph target.
+    let morph_targets: Vec<_> = primitive.morph_targets().collect();
+    assert_eq!(morph_targets.len(), 1);
+    let morph_target = &morph_targets[0];
+
+    // POSITION displacement is present.
+    assert!(morph_target.positions().is_some());
+    // TEXCOORD_0 displacement is present and accessible via the set accessor.
+    assert!(morph_target.tex_coords(0).is_some());
+    assert!(morph_target.tex_coords(1).is_none());
+    // COLOR_0 displacement is present and accessible via the set accessor.
+    assert!(morph_target.colors(0).is_some());
+    assert!(morph_target.colors(1).is_none());
+
+    // Set-index iterators report the expected sets.
+    let tex_coords_sets: Vec<u32> = morph_target.tex_coords_sets().collect();
+    assert_eq!(tex_coords_sets, [0]);
+    let colors_sets: Vec<u32> = morph_target.colors_sets().collect();
+    assert_eq!(colors_sets, [0]);
+
+    let reader = primitive
+        .reader(|buffer: gltf::Buffer| buffers.get(buffer.index()).map(|data| &data.0[..]));
+
+    // The existing read_morph_targets() iterator still yields the P/N/T tuple.
+    {
+        let mut morph_targets = reader.read_morph_targets();
+        let (positions, normals, tangents) = morph_targets.next().unwrap();
+        assert!(positions.is_some());
+        assert!(normals.is_none());
+        assert!(tangents.is_none());
+        assert!(morph_targets.next().is_none());
+    }
+
+    // read_morph_target_tex_coords(0) yields one item (one morph target),
+    // which is Some(ReadTexCoords::F32(..)) for this asset.
+    {
+        let mut mt_tex_coords = reader.read_morph_target_tex_coords(0);
+        let tex_coords_opt = mt_tex_coords.next().unwrap();
+        assert!(tex_coords_opt.is_some(), "TEXCOORD_0 displacement expected");
+        let tex_coords = tex_coords_opt.unwrap();
+        let uv: Vec<[f32; 2]> = tex_coords.into_f32().collect();
+        assert_eq!(
+            uv,
+            [[0.05, 0.05], [0.1, 0.0], [0.0, 0.1]],
+            "morph target TEXCOORD_0 displacements"
+        );
+        assert!(mt_tex_coords.next().is_none());
+    }
+
+    // Requesting a set that doesn't exist on any morph target still iterates
+    // once (one morph target), yielding None for that morph target.
+    {
+        let mut mt_tex_coords_missing = reader.read_morph_target_tex_coords(7);
+        assert!(mt_tex_coords_missing.next().unwrap().is_none());
+        assert!(mt_tex_coords_missing.next().is_none());
+    }
+
+    // read_morph_target_colors(0) yields one item, which is
+    // Some(ReadColors::RgbF32(..)) for this asset.
+    let mut mt_colors = reader.read_morph_target_colors(0);
+    let colors_opt = mt_colors.next().unwrap();
+    assert!(colors_opt.is_some(), "COLOR_0 displacement expected");
+    let colors = colors_opt.unwrap();
+    let rgb: Vec<[f32; 3]> = colors.into_rgb_f32().collect();
+    assert_eq!(
+        rgb,
+        [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 0.1]],
+        "morph target COLOR_0 displacements"
+    );
+    assert!(mt_colors.next().is_none());
+}


### PR DESCRIPTION
Closes #432.

Per the [glTF 2.0 spec morph-targets section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets), a morph target dictionary may contain numbered `TEXCOORD_<n>` and `COLOR_<n>` attribute deviations in addition to the existing `POSITION`/`NORMAL`/`TANGENT`. This PR adds support for those, closing #432.

## Changes

### `gltf-json`
- `json::mesh::MorphTarget` gains two new fields:
  - `tex_coords: BTreeMap<u32, Index<Accessor>>` (keyed by `TEXCOORD_<n>` set index)
  - `colors: BTreeMap<u32, Index<Accessor>>` (keyed by `COLOR_<n>` set index)
- Manual `Serialize`/`Deserialize` implementations handle the numbered `TEXCOORD_<n>`/`COLOR_<n>` JSON keys; unknown keys are ignored for forward-compatibility with future spec revisions.
- A manual `Default` impl is provided so downstream code constructing `MorphTarget` with struct literals can use `..Default::default()` to absorb the new fields, easing migration from the breaking field addition.
- `VALID_MORPH_TARGETS` extended to include `TEXCOORD` and `COLOR` (was previously dead code; still only documentation).
- `Primitive.targets` doc comment updated to mention the new attribute names.

### `gltf`
- `mesh::MorphTarget` gains:
  - `tex_coords(set: u32) -> Option<Accessor>`
  - `colors(set: u32) -> Option<Accessor>`
  - `tex_coords_sets() -> impl Iterator<Item = u32>`
  - `colors_sets() -> impl Iterator<Item = u32>`
- `mesh::Reader` gains:
  - `read_morph_target_tex_coords(set: u32) -> ReadMorphTargetTexCoords` — yields one `Option<ReadTexCoords>` per morph target, mirroring `read_tex_coords`.
  - `read_morph_target_colors(set: u32) -> ReadMorphTargetColors` — yields one `Option<ReadColors>` per morph target, mirroring `read_colors`.
- New `ReadMorphTargetTexCoords` / `ReadMorphTargetColors` iterator types re-use the existing `ReadTexCoords` / `ReadColors` enums and their casting adapters. The morph-target iterator is stored in the struct and advanced with `next()` so iteration is O(n) over the number of morph targets (not O(n^2)).

### Non-breaking
The existing `read_morph_targets()` tuple shape `(Option<positions>, Option<normals>, Option<tangents>)` is unchanged. Note: adding fields to the public `json::mesh::MorphTarget` struct is technically a breaking change for downstream struct-literal construction; the `Default` impl mitigates this via `..Default::default()`.

## Test
- New sample asset `tests/morphed_texcoord_color.gltf`: a triangle primitive with base `TEXCOORD_0`/`TEXCOORD_1`/`COLOR_0`/`COLOR_1` attributes and one morph target carrying `POSITION`, `TEXCOORD_0`/`TEXCOORD_1` and `COLOR_0`/`COLOR_1` displacements (distinct delta values per set).
- New test `test_morph_target_tex_coords_and_colors` asserts:
  - the morph target exposes both `TEXCOORD_0`/`TEXCOORD_1` and `COLOR_0`/`COLOR_1` accessors and the set iterators return `[0, 1]`
  - `read_morph_target_tex_coords(0)`/`read_morph_target_tex_coords(1)` return the expected set-0 / set-1 UV deltas (distinct per set)
  - `read_morph_target_colors(0)`/`read_morph_target_colors(1)` return the expected set-0 / set-1 RGB deltas
  - the existing `read_morph_targets()` tuple still works
  - requesting a missing set yields `None` per morph target
- JSON round-trip via the `gltf-roundtrip` example preserves `TEXCOORD_0`/`TEXCOORD_1`/`COLOR_0`/`COLOR_1` in the morph target dictionary.